### PR TITLE
[codex] Add declarative FigureSpec plotting

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,6 +33,66 @@ In compact mode, use `origin_query_knowledge` or `origin_browse_knowledge` to
 discover the right high-level workflow instead of choosing from every
 specialized wrapper.
 
+## FigureSpec Tools
+
+`origin-mcp` includes a first-pass declarative FigureSpec workflow for
+agent-friendly plotting plans. A FigureSpec describes the desired figure in
+terms of data, page, layer, plot, annotation, style, export, and QA sections.
+The MCP server then validates the structure and translates the supported subset
+into existing Origin plotting and formatting calls.
+
+Use `origin_plan_figure_spec(spec)` to validate a JSON FigureSpec and return
+the planned Origin operations without touching Origin. Planning reads the data
+file headers and verifies that mapped columns and column indexes exist before
+any Origin calls are made. Use `origin_execute_figure_spec(spec, dry_run=false)`
+to execute the current supported subset: worksheet-backed single-panel or grid
+multi-panel figures, common plot types, axis settings, panel/legend/reference
+annotations, exports, OPJU save, and graph diagnostics. Unsupported features are
+reported in the plan instead of being guessed.
+
+Minimal JSON shape:
+
+```json
+{
+  "figure": {"id": "line_demo", "title": "Line Demo"},
+  "data": [
+    {
+      "id": "ds_line",
+      "source": "data/processed/line.csv",
+      "object": "worksheet",
+      "roles": {"x": "time", "y": "response"}
+    }
+  ],
+  "page": {"layout": "grid"},
+  "layers": [
+    {
+      "id": "panel_a",
+      "data_ref": "ds_line",
+      "grid_cell": [0, 0],
+      "x": {"title": "Time (s)", "limits": "auto"},
+      "y": {"title": "Response", "limits": "auto"},
+      "panel_tag": "(a)"
+    }
+  ],
+  "plots": [
+    {
+      "id": "plot_a",
+      "layer": "panel_a",
+      "type": "line",
+      "map": {"x": "time", "y": "response"}
+    }
+  ],
+  "style": {"theme": "nature"},
+  "export": {
+    "dir_figures": "output/figures",
+    "dir_opju": "output/opju",
+    "png": {"enabled": true},
+    "pdf": {"enabled": true},
+    "qa": {"require_opju": true, "require_axis_titles": true}
+  }
+}
+```
+
 ## Knowledge Base Tools
 
 `origin-mcp` includes a local, structured knowledge base modeled as searchable

--- a/src/origin_mcp/client/graph_formatting.py
+++ b/src/origin_mcp/client/graph_formatting.py
@@ -67,6 +67,7 @@ class _GraphFormattingMixin(_OriginClientBase):
     def set_axis(
         self,
         graph_name: str | None = None,
+        layer_index: int = 0,
         axis: str = "x",
         scale: str | int | None = None,
         start: float | None = None,
@@ -75,7 +76,7 @@ class _GraphFormattingMixin(_OriginClientBase):
         title: str | None = None,
     ) -> dict[str, Any]:
         graph = self._find_or_active_graph(graph_name)
-        layer = graph[0] if hasattr(graph, "__getitem__") else graph
+        layer = self._graph_layer(graph, layer_index)
         ax = layer.axis(axis)
         if scale is not None:
             scale_value = self._axis_scale_value(scale)
@@ -101,6 +102,7 @@ class _GraphFormattingMixin(_OriginClientBase):
         }
         return {
             "graph_name": self._object_name(graph, default=graph_name or ""),
+            "layer_index": layer_index,
             "axis": axis,
             "requested": {key: value for key, value in requested.items() if value is not None},
             "axis_info": axis_info,

--- a/src/origin_mcp/models.py
+++ b/src/origin_mcp/models.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class PlotKind(str, Enum):
@@ -133,6 +133,7 @@ class GraphFormatRequest(BaseModel):
 
 class AxisSettingsRequest(BaseModel):
     graph_name: str | None = Field(default=None, description="Optional graph page name.")
+    layer_index: int = Field(default=0, description="Zero-based graph layer index.")
     axis: str = Field(default="x", description="Axis name: x, y, x2, y2, z, or z2.")
     scale: str | int | None = Field(
         default=None,
@@ -187,6 +188,186 @@ class AnalysisRequest(BaseModel):
         default=100,
         description="Maximum rows to read from an output worksheet.",
     )
+
+
+class FigureMeta(BaseModel):
+    id: str = Field(description="Stable figure identifier.")
+    title: str | None = Field(default=None, description="Optional figure title/long name.")
+
+
+class FigureRuntimeSpec(BaseModel):
+    show_origin: bool = Field(default=True, description="Whether Origin should be visible.")
+    new_project: bool = Field(default=False, description="Start a fresh Origin project first.")
+    save_project: bool = Field(default=False, description="Save the Origin project after export.")
+    project_path: Path | None = Field(default=None, description="Optional OPJU/OPJ save path.")
+
+
+class FigureDataSpec(BaseModel):
+    id: str = Field(description="Dataset id referenced by layers and plots.")
+    source: Path = Field(description="Source data file path.")
+    format: str | None = Field(default=None, description="csv/tsv/txt/dat/xlsx/xls/xlsm.")
+    object: Literal["worksheet", "matrix", "xyz"] = Field(default="worksheet")
+    roles: dict[str, str | int | list[str | int]] = Field(
+        default_factory=dict,
+        description="Semantic column roles such as x, y, z, group, error, err_low, err_high.",
+    )
+    excel_sheet: str | int | None = 0
+    delimiter: str | None = None
+    encoding: str | None = None
+    header: int | None = 0
+    skiprows: int | list[int] | None = None
+    nrows: int | None = None
+    na_values: str | list[str] | None = None
+
+    @field_validator("source")
+    @classmethod
+    def source_must_exist(cls, value: Path) -> Path:
+        if not value.exists():
+            raise ValueError(f"Data file does not exist: {value}")
+        if not value.is_file():
+            raise ValueError(f"Data path is not a file: {value}")
+        supported = {".csv", ".tsv", ".txt", ".dat", ".xls", ".xlsx", ".xlsm"}
+        if value.suffix.lower() not in supported:
+            raise ValueError(f"Unsupported data file extension: {value.suffix}")
+        return value
+
+
+class FigureAxisSpec(BaseModel):
+    title: str | None = None
+    scale: str | int | None = None
+    limits: Literal["auto"] | list[float | None] | None = "auto"
+    step: float | None = None
+
+
+class FigurePageSpec(BaseModel):
+    id: str = Field(default="page_main")
+    layout: Literal["single", "grid", "custom"] = Field(default="single")
+    size_mm: list[float] | None = None
+    margins_mm: list[float] | None = None
+    panel_spacing_mm: list[float] | None = None
+
+
+class FigureLayerSpec(BaseModel):
+    id: str = Field(description="Layer/panel id.")
+    page: str | None = None
+    position_mode: Literal["grid", "absolute"] = Field(default="grid")
+    grid_cell: list[int] | None = None
+    grid_span: list[int] | None = None
+    title: str | None = None
+    panel_tag: str | None = None
+    data_ref: str | None = None
+    x: FigureAxisSpec = Field(default_factory=FigureAxisSpec)
+    y: FigureAxisSpec = Field(default_factory=FigureAxisSpec)
+    frame: dict[str, bool] = Field(default_factory=dict)
+
+
+class FigurePlotSpec(BaseModel):
+    id: str = Field(description="Plot primitive id.")
+    layer: str
+    type: str = Field(description="line/scatter/line_symbol/column/histogram/box/contour/heatmap.")
+    data_ref: str | None = None
+    map: dict[str, str | int | list[str | int]] = Field(
+        default_factory=dict,
+        description="Visual channel mapping such as x, y, z, group, error.",
+    )
+    style: dict[str, Any] = Field(default_factory=dict)
+    group_style: dict[str, Any] = Field(default_factory=dict)
+    uncertainty: dict[str, Any] = Field(default_factory=dict)
+
+
+class FigureAnnotationSpec(BaseModel):
+    id: str | None = None
+    type: str
+    layer: str | None = None
+    text: str | None = None
+    location: str | None = None
+    frame: bool | None = None
+    value: float | None = None
+    orientation: str | None = None
+    style: dict[str, Any] = Field(default_factory=dict)
+
+
+class FigureStyleSpec(BaseModel):
+    theme: Literal["origin_default", "template", "theme", "none", "publication", "nature"] = (
+        "origin_default"
+    )
+    template: str | None = None
+    font_family: str | None = None
+    palette_role: str | None = None
+
+
+class FigureExportFormatSpec(BaseModel):
+    enabled: bool = False
+    path: Path | None = None
+    width_px: int | None = None
+
+
+class FigureExportSpec(BaseModel):
+    dir_figures: Path | None = None
+    dir_opju: Path | None = None
+    png: FigureExportFormatSpec | bool | None = None
+    pdf: FigureExportFormatSpec | bool | None = None
+    svg: FigureExportFormatSpec | bool | None = None
+    tiff: FigureExportFormatSpec | bool | None = None
+    save_clean_data: bool = False
+    qa: dict[str, Any] = Field(default_factory=dict)
+
+
+class FigureSpec(BaseModel):
+    figure: FigureMeta
+    runtime: FigureRuntimeSpec = Field(default_factory=FigureRuntimeSpec)
+    data: list[FigureDataSpec] = Field(default_factory=list)
+    page: FigurePageSpec = Field(default_factory=FigurePageSpec)
+    layers: list[FigureLayerSpec] = Field(default_factory=list)
+    plots: list[FigurePlotSpec] = Field(default_factory=list)
+    annotations: list[FigureAnnotationSpec] = Field(default_factory=list)
+    style: FigureStyleSpec = Field(default_factory=FigureStyleSpec)
+    export: FigureExportSpec = Field(default_factory=FigureExportSpec)
+
+    @model_validator(mode="after")
+    def validate_refs(self) -> "FigureSpec":
+        if not self.data:
+            raise ValueError("FigureSpec requires at least one data item.")
+        if not self.layers:
+            raise ValueError("FigureSpec requires at least one layer.")
+        if not self.plots:
+            raise ValueError("FigureSpec requires at least one plot.")
+
+        data_ids = _require_unique("data", [item.id for item in self.data])
+        layer_ids = _require_unique("layers", [item.id for item in self.layers])
+        _require_unique("plots", [item.id for item in self.plots])
+
+        for layer in self.layers:
+            if layer.data_ref is not None and layer.data_ref not in data_ids:
+                raise ValueError(
+                    f"Layer {layer.id!r} references unknown data_ref {layer.data_ref!r}."
+                )
+        for plot in self.plots:
+            if plot.layer not in layer_ids:
+                raise ValueError(f"Plot {plot.id!r} references unknown layer {plot.layer!r}.")
+            if plot.data_ref is not None and plot.data_ref not in data_ids:
+                raise ValueError(
+                    f"Plot {plot.id!r} references unknown data_ref {plot.data_ref!r}."
+                )
+        for annotation in self.annotations:
+            if annotation.layer is not None and annotation.layer not in layer_ids:
+                raise ValueError(
+                    f"Annotation {annotation.id or annotation.type!r} references unknown layer "
+                    f"{annotation.layer!r}."
+                )
+        return self
+
+
+def _require_unique(label: str, values: list[str]) -> set[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    if duplicates:
+        raise ValueError(f"Duplicate {label} ids: {sorted(duplicates)}")
+    return seen
 
 
 class ToolResult(BaseModel):

--- a/src/origin_mcp/server.py
+++ b/src/origin_mcp/server.py
@@ -52,6 +52,10 @@ from .tools.bridge import (
     origin_doctor,
     origin_ping,
 )
+from .tools.figurespec import (
+    origin_execute_figure_spec,
+    origin_plan_figure_spec,
+)
 from .tools.graph import (
     origin_add_graph_label,
     origin_add_plot_to_graph,

--- a/src/origin_mcp/tools/_shared.py
+++ b/src/origin_mcp/tools/_shared.py
@@ -31,6 +31,8 @@ COMPACT_TOOL_NAMES = frozenset(
         "origin_capabilities",
         "origin_browse_knowledge",
         "origin_query_knowledge",
+        "origin_plan_figure_spec",
+        "origin_execute_figure_spec",
         "origin_import_table",
         "origin_read_worksheet",
         "origin_write_worksheet",

--- a/src/origin_mcp/tools/figurespec.py
+++ b/src/origin_mcp/tools/figurespec.py
@@ -1,0 +1,679 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from origin_mcp.file_io import read_table
+from origin_mcp.models import FigureExportFormatSpec, FigureSpec
+
+from ._shared import _mcp_tool, _ok, _wrap, client
+
+
+SUPPORTED_PLOT_TYPES = {
+    "line",
+    "scatter",
+    "line_symbol",
+    "column",
+    "histogram",
+    "box",
+    "contour",
+    "heatmap",
+}
+SUPPORTED_LAYOUTS = {"single", "grid"}
+
+
+@_mcp_tool()
+def origin_plan_figure_spec(spec: dict[str, Any]) -> dict[str, Any]:
+    """Validate a declarative FigureSpec and return the planned Origin operations."""
+
+    return _wrap(
+        lambda: _ok("Planned FigureSpec.", **_plan_figure(FigureSpec.model_validate(spec)))
+    )
+
+
+@_mcp_tool()
+def origin_execute_figure_spec(
+    spec: dict[str, Any],
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Execute a declarative FigureSpec.
+
+    The current executor supports worksheet-backed single-panel and grid
+    multi-panel figures with common plot types. Unsupported features are
+    reported in the plan instead of being guessed.
+    """
+
+    def run() -> dict[str, Any]:
+        figure_spec = FigureSpec.model_validate(spec)
+        plan = _plan_figure(figure_spec)
+        if dry_run:
+            return _ok("Planned FigureSpec.", **plan)
+        if not plan["executor_executable"]:
+            return _ok(
+                "FigureSpec is valid but this executor cannot run it yet.",
+                **plan,
+                executed=False,
+            )
+        result = _execute_figure(figure_spec, plan)
+        return _ok("Executed FigureSpec.", **result)
+
+    return _wrap(run)
+
+
+def _plan_figure(spec: FigureSpec) -> dict[str, Any]:
+    data_validation = _validate_data_columns(spec)
+    warnings = _executor_warnings(spec)
+    operations: list[dict[str, Any]] = []
+
+    if spec.runtime.new_project:
+        operations.append({"op": "new_project", "show_origin": spec.runtime.show_origin})
+
+    for item in spec.data:
+        operations.append(
+            {
+                "op": "load_data",
+                "id": item.id,
+                "source": str(item.source),
+                "object": item.object,
+                "roles": item.roles,
+            }
+        )
+
+    for layer in spec.layers:
+        operations.append(
+            {
+                "op": "configure_layer",
+                "id": layer.id,
+                "data_ref": layer.data_ref,
+                "x": layer.x.model_dump(exclude_none=True),
+                "y": layer.y.model_dump(exclude_none=True),
+                "panel_tag": layer.panel_tag,
+                "grid_cell": layer.grid_cell,
+            }
+        )
+
+    for plot in spec.plots:
+        operations.append(
+            {
+                "op": "plot",
+                "id": plot.id,
+                "type": _normalize_plot_type(plot.type),
+                "layer": plot.layer,
+                "data_ref": _plot_data_ref(spec, plot),
+                "map": plot.map,
+            }
+        )
+
+    if spec.page.layout == "grid" and len(spec.layers) > 1:
+        rows, columns = _grid_shape(spec)
+        operations.append({"op": "arrange_layers", "rows": rows, "columns": columns})
+
+    for annotation in spec.annotations:
+        operations.append(
+            {
+                "op": "annotate",
+                "id": annotation.id,
+                "type": annotation.type,
+                "layer": annotation.layer,
+                "text": annotation.text,
+                "location": annotation.location,
+            }
+        )
+
+    for path in _export_paths(spec):
+        operations.append({"op": "export_graph", "path": str(path)})
+
+    project_path = _project_path(spec)
+    if spec.runtime.save_project or project_path:
+        operations.append(
+            {"op": "save_project", "path": str(project_path) if project_path else None}
+        )
+
+    qa = spec.export.qa
+    if qa:
+        operations.append({"op": "qa", "requirements": qa})
+
+    executable = not warnings
+    return {
+        "figure_id": spec.figure.id,
+        "title": spec.figure.title,
+        "executor_executable": executable,
+        "warnings": warnings,
+        "data_validation": data_validation,
+        "operations": operations,
+        "exports": [str(path) for path in _export_paths(spec)],
+        "project_path": str(project_path) if project_path else None,
+    }
+
+
+def _execute_figure(spec: FigureSpec, plan: dict[str, Any]) -> dict[str, Any]:
+    layer_indexes = {layer.id: index for index, layer in enumerate(spec.layers)}
+    base_plot = _base_plot(spec)
+    base_layer = _layer_by_id(spec, base_plot.layer)
+    base_data = _data_by_id(spec, _plot_data_ref(spec, base_plot))
+    worksheet_refs: dict[str, Any] = {}
+
+    if spec.runtime.new_project:
+        client.new_project(show=spec.runtime.show_origin)
+
+    worksheet, graph, command = _create_base_graph(spec, base_data, base_layer, base_plot)
+    worksheet_refs[base_data.id] = worksheet
+    graph_data = graph.as_dict()
+    graph_name = graph_data.get("graph_name")
+
+    for data in spec.data:
+        if data.id not in worksheet_refs:
+            worksheet_refs[data.id] = client.import_table(**_import_kwargs(data))
+
+    layer_setup = _ensure_layers_and_layout(spec, graph_name)
+    added_plots = _add_remaining_plots(spec, graph_name, layer_indexes, worksheet_refs, base_plot)
+
+    axis_updates = []
+    for layer in spec.layers:
+        axis_updates.extend(_apply_axis_specs(graph_name, layer, layer_indexes[layer.id]))
+    annotation_results = _apply_annotations(spec, graph_name, layer_indexes)
+    export_inspections = _export_outputs(spec, graph_data, graph_name)
+    saved_project = _save_project_if_requested(spec)
+    diagnostics = _diagnose_if_requested(spec, graph_name)
+
+    return {
+        **plan,
+        "executed": True,
+        "worksheets": {data_id: ref.as_dict() for data_id, ref in worksheet_refs.items()},
+        "worksheet": worksheet.as_dict(),
+        "graph": graph_data,
+        "command": command,
+        "layer_setup": layer_setup,
+        "added_plots": added_plots,
+        "axis_updates": axis_updates,
+        "annotations": annotation_results,
+        "export_inspections": export_inspections,
+        "saved_project": saved_project,
+        "diagnostics": diagnostics,
+    }
+
+
+def _create_base_graph(
+    spec: FigureSpec,
+    data: Any,
+    layer: Any,
+    plot: Any,
+) -> tuple[Any, Any, dict[str, Any] | None]:
+    plot_type = _normalize_plot_type(plot.type)
+    mapping = _plot_mapping(data, plot)
+    export_paths = _export_paths(spec)
+    first_export = export_paths[0] if export_paths else None
+
+    if plot_type == "heatmap":
+        worksheet, graph, command = client.plot_table_by_id(
+            path=data.source,
+            plot_type_id=243,
+            template=spec.style.template or "Contour",
+            selected_cols=_selected_xyz(mapping),
+            book_name=None,
+            sheet_name=None,
+            excel_sheet=data.excel_sheet,
+            delimiter=data.delimiter,
+            encoding=data.encoding,
+            header=data.header,
+            skiprows=data.skiprows,
+            nrows=data.nrows,
+            na_values=data.na_values,
+            graph_name=spec.figure.id,
+            title=spec.figure.title or layer.title,
+            x_label=layer.x.title,
+            y_label=layer.y.title,
+            style_mode=_style_mode(spec),
+            export_path=first_export,
+        )
+        return worksheet, graph, command
+
+    worksheet, graph = client.plot_table(
+        path=data.source,
+        kind=plot_type,
+        x_col=mapping.get("x"),
+        y_cols=_y_columns(mapping),
+        z_col=mapping.get("z"),
+        y_error_col=mapping.get("error") or mapping.get("y_error"),
+        x_error_col=mapping.get("x_error"),
+        book_name=None,
+        sheet_name=None,
+        excel_sheet=data.excel_sheet,
+        delimiter=data.delimiter,
+        encoding=data.encoding,
+        header=data.header,
+        skiprows=data.skiprows,
+        nrows=data.nrows,
+        na_values=data.na_values,
+        graph_name=spec.figure.id,
+        template=spec.style.template,
+        title=spec.figure.title or layer.title,
+        x_label=layer.x.title,
+        y_label=layer.y.title,
+        show_legend=_show_legend(spec),
+        style_mode=_style_mode(spec),
+        export_path=first_export,
+    )
+    return worksheet, graph, None
+
+
+def _add_remaining_plots(
+    spec: FigureSpec,
+    graph_name: str | None,
+    layer_indexes: dict[str, int],
+    worksheet_refs: dict[str, Any],
+    base_plot: Any,
+) -> list[dict[str, Any]]:
+    added = []
+    for plot in spec.plots:
+        if plot.id == base_plot.id:
+            continue
+        data = _data_by_id(spec, _plot_data_ref(spec, plot))
+        mapping = _plot_mapping(data, plot)
+        for y_col in _y_columns(mapping) or [None]:
+            result = client.add_plot_to_graph(
+                worksheet=_worksheet_ref_expr(worksheet_refs[data.id]),
+                x_col=mapping.get("x"),
+                y_col=y_col,
+                graph_name=graph_name,
+                layer_index=layer_indexes[plot.layer],
+                plot_type=_normalize_plot_type(plot.type),
+                z_col=mapping.get("z"),
+                y_error_col=mapping.get("error") or mapping.get("y_error"),
+                x_error_col=mapping.get("x_error"),
+            )
+            added.append({"plot_id": plot.id, "y_col": y_col, **result})
+    return added
+
+
+def _ensure_layers_and_layout(spec: FigureSpec, graph_name: str | None) -> dict[str, Any]:
+    layer_count = len(spec.layers)
+    added_layers = 0
+    if layer_count > 1:
+        script = _add_layers_script(graph_name, layer_count - 1)
+        if script:
+            client.run_labtalk(script)
+            added_layers = layer_count - 1
+
+    arranged = None
+    if spec.page.layout == "grid" and layer_count > 1:
+        rows, columns = _grid_shape(spec)
+        arranged = client.arrange_layers(graph_name=graph_name, rows=rows, columns=columns)
+    return {"added_layers": added_layers, "arranged": arranged}
+
+
+def _add_layers_script(graph_name: str | None, count: int) -> str:
+    if count <= 0:
+        return ""
+    parts = []
+    if graph_name:
+        parts.append(f'win -a "{_escape_labtalk(graph_name)}";')
+    parts.extend("layadd;" for _ in range(count))
+    return " ".join(parts)
+
+
+def _validate_data_columns(spec: FigureSpec) -> dict[str, Any]:
+    datasets = []
+    missing: list[dict[str, Any]] = []
+    data_by_id = {item.id: item for item in spec.data}
+    columns_by_id: dict[str, list[str]] = {}
+
+    for data in spec.data:
+        df = read_table(
+            data.source,
+            excel_sheet=data.excel_sheet,
+            delimiter=data.delimiter,
+            encoding=data.encoding,
+            header=data.header,
+            skiprows=data.skiprows,
+            nrows=0,
+            na_values=data.na_values,
+        )
+        columns = [str(column) for column in df.columns]
+        columns_by_id[data.id] = columns
+        datasets.append(
+            {
+                "id": data.id,
+                "source": str(data.source),
+                "columns": columns,
+                "column_count": len(columns),
+            }
+        )
+
+    for data in spec.data:
+        missing.extend(
+            _missing_mapping_columns(data.id, "roles", data.roles, columns_by_id[data.id])
+        )
+
+    for plot in spec.plots:
+        data_id = _plot_data_ref(spec, plot)
+        data = data_by_id[data_id]
+        mapping = _plot_mapping(data, plot)
+        missing.extend(
+            _missing_mapping_columns(data_id, f"plot:{plot.id}", mapping, columns_by_id[data_id])
+        )
+
+    if missing:
+        details = "; ".join(
+            f"{item['scope']} {item['channel']}={item['value']!r} not in {item['columns']}"
+            for item in missing
+        )
+        raise ValueError(f"FigureSpec data column validation failed: {details}")
+
+    return {"ok": True, "datasets": datasets}
+
+
+def _missing_mapping_columns(
+    data_id: str,
+    scope: str,
+    mapping: dict[str, Any],
+    columns: list[str],
+) -> list[dict[str, Any]]:
+    missing = []
+    for channel, value in mapping.items():
+        for item in _as_column_values(value):
+            if isinstance(item, int):
+                if item < 0 or item >= len(columns):
+                    missing.append(
+                        {
+                            "data_id": data_id,
+                            "scope": scope,
+                            "channel": channel,
+                            "value": item,
+                            "columns": columns,
+                        }
+                    )
+                continue
+            if isinstance(item, str) and item not in columns:
+                missing.append(
+                    {
+                        "data_id": data_id,
+                        "scope": scope,
+                        "channel": channel,
+                        "value": item,
+                        "columns": columns,
+                    }
+                )
+    return missing
+
+
+def _executor_warnings(spec: FigureSpec) -> list[str]:
+    warnings: list[str] = []
+    if any(item.object != "worksheet" for item in spec.data):
+        warnings.append("executor_supports_only_worksheet_data")
+    for plot in spec.plots:
+        plot_type = _normalize_plot_type(plot.type)
+        mapping = _plot_mapping(_data_by_id(spec, _plot_data_ref(spec, plot)), plot)
+        if plot_type not in SUPPORTED_PLOT_TYPES:
+            warnings.append(f"unsupported_executor_plot_type:{plot.type}")
+        if plot.id != _base_plot(spec).id and plot_type != "histogram" and mapping.get("y") is None:
+            warnings.append("executor_requires_y_mapping_for_additional_plots")
+        if plot.map.get("group") or plot.group_style:
+            warnings.append("executor_does_not_apply_group_style")
+        if plot.uncertainty:
+            warnings.append("executor_does_not_apply_uncertainty_bands")
+    if spec.page.layout not in SUPPORTED_LAYOUTS:
+        warnings.append("executor_supports_only_single_or_grid_layout")
+    if len(spec.layers) > 1 and not any(plot.layer == spec.layers[0].id for plot in spec.plots):
+        warnings.append("executor_requires_at_least_one_plot_on_first_layer")
+    if any(_normalize_plot_type(plot.type) == "histogram" for plot in spec.plots[1:]):
+        warnings.append("executor_supports_histogram_only_as_first_plot")
+    return sorted(set(warnings))
+
+
+def _base_plot(spec: FigureSpec) -> Any:
+    first_layer_id = spec.layers[0].id
+    return next((plot for plot in spec.plots if plot.layer == first_layer_id), spec.plots[0])
+
+
+def _plot_data_ref(spec: FigureSpec, plot: Any) -> str:
+    if plot.data_ref:
+        return plot.data_ref
+    layer = next((item for item in spec.layers if item.id == plot.layer), None)
+    if layer and layer.data_ref:
+        return layer.data_ref
+    return spec.data[0].id
+
+
+def _data_by_id(spec: FigureSpec, data_id: str | None) -> Any:
+    for data in spec.data:
+        if data.id == data_id:
+            return data
+    raise ValueError(f"Unknown data id: {data_id!r}")
+
+
+def _layer_by_id(spec: FigureSpec, layer_id: str) -> Any:
+    for layer in spec.layers:
+        if layer.id == layer_id:
+            return layer
+    raise ValueError(f"Unknown layer id: {layer_id!r}")
+
+
+def _plot_mapping(data: Any, plot: Any) -> dict[str, Any]:
+    return {**data.roles, **plot.map}
+
+
+def _normalize_plot_type(value: str) -> str:
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _style_mode(spec: FigureSpec) -> str:
+    if spec.style.template and spec.style.theme in {"origin_default", "template"}:
+        return "template"
+    return spec.style.theme
+
+
+def _show_legend(spec: FigureSpec) -> bool:
+    for item in spec.annotations:
+        if item.type.strip().lower() == "legend":
+            return True
+    return True
+
+
+def _y_columns(mapping: dict[str, Any]) -> list[str | int] | None:
+    y_value = mapping.get("y")
+    if y_value is None:
+        return None
+    if isinstance(y_value, list):
+        return y_value
+    return [y_value]
+
+
+def _selected_xyz(mapping: dict[str, Any]) -> list[str | int]:
+    return [mapping.get("x", 0), mapping.get("y", 1), mapping.get("z", 2)]
+
+
+def _apply_axis_specs(
+    graph_name: str | None,
+    layer: Any,
+    layer_index: int,
+) -> list[dict[str, Any]]:
+    updates = []
+    for axis_name, axis_spec in (("x", layer.x), ("y", layer.y)):
+        start = end = None
+        limits = axis_spec.limits
+        if isinstance(limits, list):
+            start = limits[0] if len(limits) > 0 else None
+            end = limits[1] if len(limits) > 1 else None
+        if axis_spec.scale is None and start is None and end is None and axis_spec.step is None:
+            continue
+        updates.append(
+            {
+                "layer_index": layer_index,
+                **client.set_axis(
+                    graph_name=graph_name,
+                    layer_index=layer_index,
+                    axis=axis_name,
+                    scale=axis_spec.scale,
+                    start=start,
+                    end=end,
+                    step=axis_spec.step,
+                    title=axis_spec.title,
+                ),
+            }
+        )
+    return updates
+
+
+def _apply_annotations(
+    spec: FigureSpec,
+    graph_name: str | None,
+    layer_indexes: dict[str, int],
+) -> list[dict[str, Any]]:
+    results = []
+    for layer in spec.layers:
+        if layer.panel_tag:
+            results.append(
+                client.add_graph_label(
+                    text=layer.panel_tag,
+                    graph_name=graph_name,
+                    layer_index=layer_indexes[layer.id],
+                    name=f"{layer.id}_panel_tag",
+                    font_size=8,
+                )
+            )
+    for annotation in spec.annotations:
+        kind = annotation.type.strip().lower()
+        layer_index = layer_indexes.get(annotation.layer or spec.layers[0].id, 0)
+        if kind == "legend":
+            results.append(
+                client.format_legend(
+                    graph_name=graph_name,
+                    show_frame=annotation.frame,
+                    position=annotation.location,
+                )
+            )
+        elif kind in {"panel_tag", "text"} and annotation.text:
+            results.append(
+                client.add_graph_label(
+                    text=annotation.text,
+                    graph_name=graph_name,
+                    layer_index=layer_index,
+                    name=annotation.id,
+                    font_size=8,
+                )
+            )
+        elif kind == "reference_line" and annotation.value is not None:
+            axis = "x" if (annotation.orientation or "").lower().startswith("v") else "y"
+            results.append(
+                client.add_reference_line(
+                    value=annotation.value,
+                    axis=axis,
+                    graph_name=graph_name,
+                    layer_index=layer_index,
+                    label=annotation.text,
+                )
+            )
+    return results
+
+
+def _export_outputs(
+    spec: FigureSpec,
+    graph_data: dict[str, Any],
+    graph_name: str | None,
+) -> list[dict[str, Any]]:
+    export_paths = _export_paths(spec)
+    exported = []
+    first_export = export_paths[0] if export_paths else None
+    if first_export and graph_data.get("export_path"):
+        exported.append(client.inspect_export(Path(graph_data["export_path"])))
+    for path in export_paths[1:]:
+        item = client.export_graph(path, graph_name=graph_name, overwrite=True)
+        exported.append(client.inspect_export(Path(item["path"])))
+    return exported
+
+
+def _save_project_if_requested(spec: FigureSpec) -> dict[str, Any] | None:
+    project_path = _project_path(spec)
+    if not spec.runtime.save_project and not project_path:
+        return None
+    if project_path is None:
+        project_path = Path(f"{spec.figure.id}.opju")
+    return client.save_project(project_path)
+
+
+def _diagnose_if_requested(spec: FigureSpec, graph_name: str | None) -> dict[str, Any] | None:
+    if not spec.export.qa:
+        return None
+    return client.diagnose_graph(
+        graph_name=graph_name,
+        style=spec.style.theme,
+        palette_role=spec.style.palette_role,
+        require_axis_titles=bool(spec.export.qa.get("require_axis_titles", True)),
+        require_plots=bool(spec.export.qa.get("require_plots", True)),
+        require_legend=bool(spec.export.qa.get("require_legend", False)),
+        require_panel_label=bool(spec.export.qa.get("require_panel_label", False)),
+    )
+
+
+def _export_paths(spec: FigureSpec) -> list[Path]:
+    paths = []
+    for suffix in ("png", "pdf", "svg", "tiff"):
+        item = getattr(spec.export, suffix)
+        if not _export_enabled(item):
+            continue
+        path = item.path if isinstance(item, FigureExportFormatSpec) else None
+        if path is None:
+            output_dir = spec.export.dir_figures or Path("output") / "figures"
+            path = output_dir / f"{spec.figure.id}.{suffix}"
+        paths.append(path)
+    return paths
+
+
+def _export_enabled(item: FigureExportFormatSpec | bool | None) -> bool:
+    if isinstance(item, bool):
+        return item
+    if item is None:
+        return False
+    return item.enabled
+
+
+def _project_path(spec: FigureSpec) -> Path | None:
+    if spec.runtime.project_path:
+        return spec.runtime.project_path
+    if spec.export.dir_opju and (spec.runtime.save_project or spec.export.qa.get("require_opju")):
+        return spec.export.dir_opju / f"{spec.figure.id}.opju"
+    return None
+
+
+def _grid_shape(spec: FigureSpec) -> tuple[int, int]:
+    rows = 1
+    columns = max(1, len(spec.layers))
+    for index, layer in enumerate(spec.layers):
+        cell = layer.grid_cell or [index // columns, index % columns]
+        span = layer.grid_span or [1, 1]
+        rows = max(rows, int(cell[0]) + int(span[0]))
+        columns = max(columns, int(cell[1]) + int(span[1]))
+    if any(layer.grid_cell for layer in spec.layers):
+        return rows, columns
+    if spec.page.layout == "grid" and len(spec.layers) > 1:
+        columns = 2 if len(spec.layers) > 2 else len(spec.layers)
+        rows = (len(spec.layers) + columns - 1) // columns
+    return rows, columns
+
+
+def _import_kwargs(data: Any) -> dict[str, Any]:
+    return {
+        "path": data.source,
+        "book_name": None,
+        "sheet_name": None,
+        "excel_sheet": data.excel_sheet,
+        "delimiter": data.delimiter,
+        "encoding": data.encoding,
+        "header": data.header,
+        "skiprows": data.skiprows,
+        "nrows": data.nrows,
+        "na_values": data.na_values,
+    }
+
+
+def _worksheet_ref_expr(ref: Any) -> str:
+    return f"[{ref.book_name}]{ref.sheet_name}"
+
+
+def _as_column_values(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else [value]
+
+
+def _escape_labtalk(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/origin_mcp/tools/graph.py
+++ b/src/origin_mcp/tools/graph.py
@@ -170,6 +170,7 @@ def origin_format_graph(
 @_mcp_tool()
 def origin_set_axis(
     graph_name: str | None = None,
+    layer_index: int = 0,
     axis: str = "x",
     scale: str | int | None = None,
     start: float | None = None,
@@ -182,6 +183,7 @@ def origin_set_axis(
     def run() -> dict[str, Any]:
         req = AxisSettingsRequest(
             graph_name=graph_name,
+            layer_index=layer_index,
             axis=axis,
             scale=scale,
             start=start,

--- a/tests/test_figurespec.py
+++ b/tests/test_figurespec.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import origin_mcp.tools.figurespec as figurespec_tools
+from origin_mcp.origin_client import GraphRef, WorksheetRef
+
+
+class FakeFigureSpecClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def new_project(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("new_project", kwargs))
+        return {"created": True}
+
+    def plot_table(self, **kwargs: Any) -> tuple[WorksheetRef, GraphRef]:
+        self.calls.append(("plot_table", kwargs))
+        return (
+            WorksheetRef("Book1", "Sheet1", ["time", "response"], 2),
+            GraphRef(
+                "Graph1",
+                export_path=str(kwargs["export_path"]) if kwargs.get("export_path") else None,
+                style_mode=kwargs.get("style_mode"),
+            ),
+        )
+
+    def plot_table_by_id(self, **kwargs: Any) -> tuple[WorksheetRef, GraphRef, dict[str, Any]]:
+        self.calls.append(("plot_table_by_id", kwargs))
+        return (
+            WorksheetRef("Book1", "Sheet1", ["x", "y", "z"], 2),
+            GraphRef("Heat", export_path=str(kwargs.get("export_path") or "")),
+            {"plot_type_id": kwargs["plot_type_id"]},
+        )
+
+    def set_axis(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("set_axis", kwargs))
+        return {
+            "axis": kwargs["axis"],
+            "graph_name": kwargs.get("graph_name"),
+            "layer_index": kwargs.get("layer_index", 0),
+        }
+
+    def run_labtalk(self, script: str) -> dict[str, Any]:
+        self.calls.append(("run_labtalk", {"script": script}))
+        return {"result": True, "script": script}
+
+    def arrange_layers(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("arrange_layers", kwargs))
+        return {"rows": kwargs["rows"], "columns": kwargs["columns"]}
+
+    def import_table(self, **kwargs: Any) -> WorksheetRef:
+        self.calls.append(("import_table", kwargs))
+        return WorksheetRef("Book2", "Sheet1", ["time", "other"], 2)
+
+    def add_plot_to_graph(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_plot_to_graph", kwargs))
+        return {
+            "graph_name": kwargs.get("graph_name"),
+            "layer_index": kwargs["layer_index"],
+            "plot_type": kwargs["plot_type"],
+        }
+
+    def add_graph_label(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_graph_label", kwargs))
+        return {"text": kwargs["text"]}
+
+    def format_legend(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("format_legend", kwargs))
+        return {"legend": True}
+
+    def add_reference_line(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_reference_line", kwargs))
+        return {"value": kwargs["value"]}
+
+    def export_graph(self, path: Any, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("export_graph", {"path": path, **kwargs}))
+        return {"path": str(path)}
+
+    def inspect_export(self, path: Any) -> dict[str, Any]:
+        self.calls.append(("inspect_export", {"path": path}))
+        return {"path": str(path), "looks_nonempty": True}
+
+    def diagnose_graph(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("diagnose_graph", kwargs))
+        return {"issues": []}
+
+    def save_project(self, path: Any) -> dict[str, Any]:
+        self.calls.append(("save_project", {"path": path}))
+        return {"path": str(path)}
+
+
+def _single_line_spec(path: Path, output_dir: Path) -> dict[str, Any]:
+    return {
+        "figure": {"id": "line_demo", "title": "Line Demo"},
+        "runtime": {"new_project": True, "save_project": True},
+        "data": [
+            {
+                "id": "ds_line",
+                "source": str(path),
+                "roles": {"x": "time", "y": "response"},
+            }
+        ],
+        "page": {"layout": "single"},
+        "layers": [
+            {
+                "id": "panel_a",
+                "data_ref": "ds_line",
+                "panel_tag": "(a)",
+                "x": {"title": "Time (s)", "scale": "linear", "limits": [0, 10]},
+                "y": {"title": "Response", "limits": "auto"},
+            }
+        ],
+        "plots": [
+            {
+                "id": "plot_a",
+                "layer": "panel_a",
+                "type": "line",
+                "map": {"x": "time", "y": "response"},
+            }
+        ],
+        "annotations": [{"id": "legend", "type": "legend", "layer": "panel_a", "frame": False}],
+        "style": {"theme": "nature"},
+        "export": {
+            "dir_figures": str(output_dir / "figures"),
+            "dir_opju": str(output_dir / "opju"),
+            "png": {"enabled": True},
+            "pdf": {"enabled": True},
+            "qa": {"require_opju": True, "require_axis_titles": True},
+        },
+    }
+
+
+def test_origin_plan_figure_spec_returns_operations(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("time,response\n0,1\n", encoding="utf-8")
+
+    result = figurespec_tools.origin_plan_figure_spec(_single_line_spec(data_path, tmp_path))
+
+    assert result["ok"] is True
+    assert result["data"]["executor_executable"] is True
+    assert result["data"]["data_validation"]["datasets"][0]["columns"] == ["time", "response"]
+    assert [item["op"] for item in result["data"]["operations"]] == [
+        "new_project",
+        "load_data",
+        "configure_layer",
+        "plot",
+        "annotate",
+        "export_graph",
+        "export_graph",
+        "save_project",
+        "qa",
+    ]
+
+
+def test_origin_execute_figure_spec_runs_single_layer_mvp(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("time,response\n0,1\n", encoding="utf-8")
+    fake = FakeFigureSpecClient()
+    monkeypatch.setattr(figurespec_tools, "client", fake)
+
+    result = figurespec_tools.origin_execute_figure_spec(_single_line_spec(data_path, tmp_path))
+
+    assert result["ok"] is True
+    assert result["data"]["executed"] is True
+    assert result["data"]["graph"]["graph_name"] == "Graph1"
+    called = [name for name, _kwargs in fake.calls]
+    assert called[:2] == ["new_project", "plot_table"]
+    assert "set_axis" in called
+    assert "add_graph_label" in called
+    assert "format_legend" in called
+    assert "export_graph" in called
+    assert "diagnose_graph" in called
+    assert "save_project" in called
+
+
+def test_origin_execute_figure_spec_rejects_missing_columns(tmp_path: Path) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("x,y\n0,1\n", encoding="utf-8")
+    spec = _single_line_spec(data_path, tmp_path)
+
+    result = figurespec_tools.origin_plan_figure_spec(spec)
+
+    assert result["ok"] is False
+    assert result["error_code"] == "invalid_request"
+    assert "FigureSpec data column validation failed" in result["message"]
+
+
+def test_origin_execute_figure_spec_runs_grid_multi_panel(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("time,response,other\n0,1,2\n", encoding="utf-8")
+    spec = _single_line_spec(data_path, tmp_path)
+    spec["page"] = {"layout": "grid"}
+    spec["layers"][0]["grid_cell"] = [0, 0]
+    spec["layers"].append(
+        {
+            "id": "panel_b",
+            "data_ref": "ds_line",
+            "panel_tag": "(b)",
+            "grid_cell": [0, 1],
+            "x": {"title": "Time (s)", "limits": "auto"},
+            "y": {"title": "Other", "limits": "auto"},
+        }
+    )
+    spec["plots"].append(
+        {
+            "id": "plot_b",
+            "layer": "panel_b",
+            "type": "scatter",
+            "map": {"x": "time", "y": "other"},
+        }
+    )
+    fake = FakeFigureSpecClient()
+    monkeypatch.setattr(figurespec_tools, "client", fake)
+
+    result = figurespec_tools.origin_execute_figure_spec(spec)
+
+    assert result["ok"] is True
+    assert result["data"]["executed"] is True
+    assert result["data"]["layer_setup"]["added_layers"] == 1
+    assert result["data"]["layer_setup"]["arranged"] == {"rows": 1, "columns": 2}
+    assert result["data"]["added_plots"][0]["plot_id"] == "plot_b"
+    called = [name for name, _kwargs in fake.calls]
+    assert "run_labtalk" in called
+    assert "arrange_layers" in called
+    assert "add_plot_to_graph" in called

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from origin_mcp.models import PlotTableRequest, TableImportRequest
+from origin_mcp.models import FigureSpec, PlotTableRequest, TableImportRequest
 
 
 def test_table_import_request_accepts_supported_files(tmp_path: Path) -> None:
@@ -30,3 +30,42 @@ def test_plot_table_request_defaults(tmp_path: Path) -> None:
     assert req.x_col is None
     assert req.y_cols is None
     assert req.show_legend is True
+
+
+def test_figurespec_validates_references(tmp_path: Path) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("time,response\n1,2\n", encoding="utf-8")
+
+    spec = FigureSpec.model_validate(
+        {
+            "figure": {"id": "fig1"},
+            "data": [{"id": "ds1", "source": str(path), "roles": {"x": "time", "y": "response"}}],
+            "layers": [{"id": "panel_a", "data_ref": "ds1"}],
+            "plots": [
+                {
+                    "id": "plot_a",
+                    "layer": "panel_a",
+                    "type": "line",
+                    "map": {"x": "time", "y": "response"},
+                }
+            ],
+        }
+    )
+
+    assert spec.figure.id == "fig1"
+    assert spec.data[0].roles["x"] == "time"
+
+
+def test_figurespec_rejects_unknown_plot_layer(tmp_path: Path) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        FigureSpec.model_validate(
+            {
+                "figure": {"id": "fig1"},
+                "data": [{"id": "ds1", "source": str(path)}],
+                "layers": [{"id": "panel_a"}],
+                "plots": [{"id": "plot_a", "layer": "missing", "type": "line"}],
+            }
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -52,7 +52,7 @@ def test_full_mcp_tool_profile_registers_all_tools() -> None:
         text=True,
     )
 
-    assert int(output.strip()) == 149
+    assert int(output.strip()) == 151
 
 
 def test_error_response_includes_stable_error_code() -> None:


### PR DESCRIPTION
## Summary

Adds a declarative FigureSpec workflow for Origin plotting. The new compact tools can validate a JSON FigureSpec, verify mapped data columns before touching Origin, and execute supported single-panel or grid multi-panel worksheet-backed plots.

## Changes

- Added FigureSpec Pydantic models and compact MCP tools: `origin_plan_figure_spec` and `origin_execute_figure_spec`.
- Added grid multi-layer execution using existing Origin bridge/client calls for plotting, layer creation, arrangement, annotations, exports, OPJU save, and diagnostics.
- Made axis formatting layer-aware via optional `layer_index` on `set_axis` / `origin_set_axis`.
- Documented the FigureSpec workflow and added focused model/tool tests.

## Validation

- `python -m compileall -q src tests`
- `python -m pytest` (221 passed)
- `git diff --check`

`ruff` could not be run in this local Python environment because the `ruff` module/command is not installed.