### PR TITLE
Add fake-Origin unit tests for client mixins; single-source version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Run tests
         run: >-
           python -m pytest -q --cov=origin_mcp --cov-report=term-missing
-          --cov-report=xml --cov-fail-under=75
+          --cov-report=xml --cov-fail-under=80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "origin-mcp"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Local MCP server that lets AI assistants automate Origin/OriginPro for data import, worksheet editing, plotting, analysis, and export on Windows."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,6 +46,12 @@ dev = [
 
 [project.scripts]
 origin-mcp = "origin_mcp.server:main"
+
+[tool.hatch.version]
+# Single source of truth: the version lives in src/origin_mcp/__init__.py
+# (__version__), which the bridge reports over its ping handshake. Keeping it
+# there avoids drift between the package metadata and the running bridge.
+path = "src/origin_mcp/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/origin_mcp"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared pytest fixtures for origin-mcp tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from fake_origin import FakeOp
+
+from origin_mcp.origin_client import OriginClient
+
+
+@pytest.fixture
+def fake_op() -> FakeOp:
+    """A fresh in-memory fake ``originpro`` module."""
+
+    return FakeOp()
+
+
+@pytest.fixture
+def fake_client(fake_op: FakeOp) -> OriginClient:
+    """An ``OriginClient`` wired to the in-memory fake originpro.
+
+    Injecting ``_op`` short-circuits the lazy ``op`` property so no real
+    ``originpro`` import is attempted. ``client.op`` is the same ``FakeOp``,
+    so tests can seed books with ``client.op.add_book(...)``.
+    """
+
+    client = OriginClient()
+    client._op = fake_op
+    return client
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4],
+            "y": [10.0, 20.0, 30.0, 40.0],
+        }
+    )

--- a/tests/fake_origin.py
+++ b/tests/fake_origin.py
@@ -1,0 +1,392 @@
+"""In-memory fake of the slice of ``originpro`` that ``OriginClient`` uses.
+
+The client mixins talk to originpro through a small, stable surface:
+``op.new_sheet``/``op.find_sheet``/``op.pages``/``op.lt_float`` and a worksheet
+object exposing ``to_df``/``from_df``/``get_book``/``get_labels``/``cols``/
+``rows``/``activate``/``lt_exec``/``add_col``. These fakes implement exactly that
+surface backed by pandas DataFrames, so the pure data-shaping logic in the
+worksheet, transform, and analysis mixins can be exercised without a real Origin
+install.
+
+Inject one onto a client with ``client._op = FakeOp(...)``; the lazy ``op``
+property then returns it instead of importing ``originpro`` (see
+``_OriginClientBase.op``).
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from typing import Any
+
+import pandas as pd
+
+_NCOLS_RE = re.compile(r"wks\.ncols\s*=\s*(\d+)\s*;?", re.IGNORECASE)
+_EXP_PATH_RE = re.compile(r'path:="([^"]*)"')
+_EXP_FILENAME_RE = re.compile(r'filename:="([^"]*)"')
+_EXP_TYPE_RE = re.compile(r"type:=(\w+)")
+
+
+class WBook:
+    def __init__(self, op: FakeOp, name: str) -> None:
+        self.op = op
+        self.name = name
+        self.lname = name
+        self.sheets: list[FakeWorksheet] = []
+
+    def __iter__(self) -> Any:
+        return iter(self.sheets)
+
+    def __getitem__(self, index: int) -> FakeWorksheet:
+        return self.sheets[index]
+
+
+class FakeWorksheet:
+    def __init__(self, book: WBook, name: str, df: pd.DataFrame | None = None) -> None:
+        self.book = book
+        self.name = name
+        self.lname = name
+        self._df = (df if df is not None else pd.DataFrame()).reset_index(drop=True)
+        self.scripts: list[str] = []
+        self.activated = 0
+        self.label_calls: list[tuple[list[str], str, int]] = []
+        self.designation_calls: list[tuple[str, int, int, bool]] = []
+
+    # -- Properties originpro exposes -------------------------------------
+    @property
+    def cols(self) -> int:
+        return int(self._df.shape[1])
+
+    @property
+    def rows(self) -> int:
+        return int(self._df.shape[0])
+
+    # -- DataFrame round trip ---------------------------------------------
+    def to_df(self, **_: Any) -> pd.DataFrame:
+        return self._df.copy()
+
+    def from_df(self, df: pd.DataFrame, c1: int | str = 0) -> None:
+        if str(c1) in ("0", ""):
+            self._df = df.reset_index(drop=True).copy()
+            return
+        # Non-zero start column: keep the leading columns, append the new frame.
+        offset = int(c1)
+        kept = self._df.iloc[:, :offset]
+        appended = df.reset_index(drop=True).copy()
+        self._df = pd.concat([kept.reset_index(drop=True), appended], axis=1)
+
+    # -- Metadata ----------------------------------------------------------
+    def get_book(self) -> WBook:
+        return self.book
+
+    # -- Range expressions (used by analysis commands) --------------------
+    def to_xy_range(self, x: Any, y: Any, _extra: str = "") -> str:
+        return f"[{self.book.name}]{self.name}!({x},{y})"
+
+    def to_col_range(self, y: Any) -> str:
+        return f"[{self.book.name}]{self.name}!({y})"
+
+    def lt_range(self, _flag: bool = False) -> str:
+        return f"[{self.book.name}]{self.name}!"
+
+    def get_labels(self, kind: str = "L") -> list[str]:
+        if kind == "L":
+            return [str(col) for col in self._df.columns]
+        return []
+
+    def add_col(self, name: str | None = None) -> None:
+        column = name or f"Col{self.cols + 1}"
+        self._df[column] = pd.NA
+
+    def set_labels(self, labels: list[str], label_type: str = "L", offset: int = 0) -> None:
+        self.label_calls.append((list(labels), label_type, offset))
+
+    def cols_axis(self, spec: str, c1: int = 0, c2: int = -1, repeat: bool = True) -> None:
+        self.designation_calls.append((spec, c1, c2, repeat))
+
+    # -- LabTalk execution -------------------------------------------------
+    def activate(self) -> None:
+        self.activated += 1
+
+    def lt_exec(self, script: str) -> int:
+        self.scripts.append(script)
+        match = _NCOLS_RE.fullmatch(script.strip())
+        if match:
+            self._df = self._df.iloc[:, : int(match.group(1))]
+        return 0
+
+
+# A minimal valid 1x1 PNG, used by GPage.save_fig so export/inspect paths that
+# read the written file (dimensions, sha256, quality) operate on a real image.
+_ONE_BY_ONE_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+class GAxis:
+    """A graph layer axis (``layer.axis("x")``)."""
+
+    def __init__(self, title: str = "") -> None:
+        self.title = title
+        self.scale: Any = 1
+        self.limits: Any = None
+
+
+class GPlot:
+    """A single data plot inside a layer."""
+
+    def __init__(self, index: int) -> None:
+        self.name = f"Plot{index + 1}"
+        self.commands: list[str] = []
+        self.props: dict[str, Any] = {}
+
+    def set_cmd(self, command: str) -> None:
+        self.commands.append(command)
+
+    def set_int(self, name: str, value: int) -> None:
+        self.props[name] = value
+
+    def set_float(self, name: str, value: float) -> None:
+        self.props[name] = value
+
+
+class GLayer:
+    """A graph layer (``graph[i]``)."""
+
+    def __init__(self, index: int) -> None:
+        self.name = f"Layer{index + 1}"
+        self.lname = self.name
+        self._axes = {"x": GAxis("X"), "y": GAxis("Y"), "z": GAxis("Z")}
+        self.plots: list[GPlot] = []
+        self.labels: dict[str, Any] = {}
+        self.rescaled = 0
+        self.grouped = False
+
+    def axis(self, name: str) -> GAxis | None:
+        return self._axes.get(name.lower())
+
+    def add_plot(self, _wks: Any, *args: Any, **kwargs: Any) -> GPlot:
+        plot = GPlot(len(self.plots))
+        self.plots.append(plot)
+        return plot
+
+    def plot_list(self) -> list[GPlot]:
+        return list(self.plots)
+
+    def rescale(self) -> None:
+        self.rescaled += 1
+
+    def group(self, *_: Any) -> None:
+        self.grouped = True
+
+    def label(self, name: str) -> Any:
+        return self.labels.get(name)
+
+
+class GPage:
+    """A graph page (``op.new_graph`` / ``op.find_graph`` result)."""
+
+    def __init__(self, name: str, lname: str | None = None, layers: int = 1) -> None:
+        self.name = name
+        self.lname = lname or name
+        self.layers = [GLayer(i) for i in range(layers)]
+        self.activated = 0
+        self.destroyed = False
+
+    def __len__(self) -> int:
+        return len(self.layers)
+
+    def __getitem__(self, index: int) -> GLayer:
+        return self.layers[index]
+
+    def activate(self) -> None:
+        self.activated += 1
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+    def is_open(self) -> bool:
+        return True
+
+    def save_fig(
+        self,
+        path: str,
+        type: str = "png",  # noqa: A002 - matches originpro signature
+        replace: bool = True,
+        width: int = 0,
+    ) -> None:
+        from pathlib import Path
+
+        Path(path).write_bytes(_ONE_BY_ONE_PNG)
+
+
+class FakeLinearFit:
+    """Stand-in for ``originpro.LinearFit``.
+
+    Not attached to ``FakeOp`` by default (so ``linear_fit_api`` stays absent in
+    capability probes); a test opts in with ``op.LinearFit = FakeLinearFit``.
+    """
+
+    def __init__(self) -> None:
+        self.data: tuple[Any, ...] | None = None
+        self.fixed_intercept: Any = None
+        self.fixed_slope: Any = None
+
+    def set_data(self, wks: Any, x: Any, y: Any, err: str = "") -> None:
+        self.data = (wks, x, y, err)
+
+    def fix_intercept(self, value: Any) -> None:
+        self.fixed_intercept = value
+
+    def fix_slope(self, value: Any) -> None:
+        self.fixed_slope = value
+
+    def result(self) -> dict[str, Any]:
+        return {"slope": 2.0, "intercept": 1.0, "r": 0.99, "adj_rsquare": 0.98}
+
+    def report(self, band: int = 0) -> tuple[str, str]:
+        return ("FitReport", "FitCurves")
+
+
+class FakeOp:
+    """Fake ``originpro`` module exposing only what OriginClient calls."""
+
+    def __init__(self) -> None:
+        self.books: list[WBook] = []
+        self.graphs: list[GPage] = []
+        self._counter = 0
+        self._graph_counter = 0
+        self.lt_values: dict[str, Any] = {}
+        # Records of lifecycle / LabTalk calls so tests can assert on side effects.
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.lt_exec_result: Any = True
+        self.show: bool | None = None
+        self.save_raises = False
+
+    # -- Test helpers ------------------------------------------------------
+    def add_book(
+        self,
+        name: str,
+        df: pd.DataFrame | None = None,
+        sheet: str = "Sheet1",
+    ) -> FakeWorksheet:
+        book = WBook(self, name)
+        wks = FakeWorksheet(book, sheet, df)
+        book.sheets.append(wks)
+        self.books.append(book)
+        return wks
+
+    def add_graph(self, name: str, lname: str | None = None, layers: int = 1) -> GPage:
+        page = GPage(name, lname=lname, layers=layers)
+        self.graphs.append(page)
+        return page
+
+    # -- originpro surface -------------------------------------------------
+    def new_sheet(self, _type: str = "w", book_name: str = "") -> FakeWorksheet:
+        self._counter += 1
+        name = book_name or f"Book{self._counter}"
+        return self.add_book(name)
+
+    def find_sheet(self, _type: str = "w", ref: str = "") -> FakeWorksheet | None:
+        ref = (ref or "").strip()
+        if ref == "":
+            return self.books[-1].sheets[0] if self.books else None
+        if ref.startswith("[") and "]" in ref:
+            book_name, rest = ref[1:].split("]", 1)
+            sheet_name = rest.split("!", 1)[0].strip() or None
+            return self._lookup(book_name, sheet_name)
+        found = self._lookup(ref, None)
+        if found is not None:
+            return found
+        for book in self.books:
+            for sheet in book.sheets:
+                if ref in (sheet.name, sheet.lname):
+                    return sheet
+        return None
+
+    def pages(self, _type: str = "") -> list[Any]:
+        if _type == "w":
+            return list(self.books)
+        if _type == "g":
+            return list(self.graphs)
+        return [*self.books, *self.graphs]
+
+    def new_graph(self, template: str = "", lname: str | None = None) -> GPage:
+        self._graph_counter += 1
+        name = f"Graph{self._graph_counter}"
+        return self.add_graph(name, lname=lname)
+
+    def find_graph(self, name: str = "") -> GPage | None:
+        name = (name or "").strip()
+        if name == "":
+            return self.graphs[-1] if self.graphs else None
+        for graph in self.graphs:
+            if name in (graph.name, graph.lname):
+                return graph
+        return None
+
+    def graph_list(self, _type: str = "p", _active_first: bool = True) -> list[GPage]:
+        return list(self.graphs)
+
+    def lt_float(self, expression: str) -> Any:
+        return self.lt_values.get(expression)
+
+    # -- Lifecycle / LabTalk surface (opt-in per test) --------------------
+    def set_show(self, show: bool) -> None:
+        self.show = show
+        self.calls.append(("set_show", (show,)))
+
+    def lt_exec(self, script: str) -> Any:
+        self.calls.append(("lt_exec", (script,)))
+        if "expGraph" in script:
+            self._emulate_export(script)
+        return self.lt_exec_result
+
+    @staticmethod
+    def _emulate_export(script: str) -> None:
+        """Emulate LabTalk ``expGraph`` writing an image file to disk."""
+
+        from pathlib import Path
+
+        path_match = _EXP_PATH_RE.search(script)
+        name_match = _EXP_FILENAME_RE.search(script)
+        if not path_match or not name_match:
+            return
+        type_match = _EXP_TYPE_RE.search(script)
+        suffix = (type_match.group(1) if type_match else "png").lstrip(".")
+        target = Path(path_match.group(1)) / f"{name_match.group(1)}.{suffix}"
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(_ONE_BY_ONE_PNG)
+        except OSError:
+            pass
+
+    def new(self) -> None:
+        self.calls.append(("new", ()))
+
+    def save(self, path: str) -> None:
+        self.calls.append(("save", (path,)))
+        if self.save_raises:
+            raise RuntimeError("originpro.save failed")
+
+    def open(self, path: str, readonly: bool = False, asksave: bool = False) -> bool:
+        self.calls.append(("open", (path, readonly, asksave)))
+        return True
+
+    def exit(self) -> None:
+        self.calls.append(("exit", ()))
+
+    def detach(self) -> None:
+        self.calls.append(("detach", ()))
+
+    def _lookup(self, book_name: str, sheet_name: str | None) -> FakeWorksheet | None:
+        for book in self.books:
+            if book_name not in (book.name, book.lname):
+                continue
+            if sheet_name:
+                for sheet in book.sheets:
+                    if sheet_name in (sheet.name, sheet.lname):
+                        return sheet
+                return None
+            return book.sheets[0] if book.sheets else None
+        return None

--- a/tests/test_analysis_helpers.py
+++ b/tests/test_analysis_helpers.py
@@ -1,0 +1,144 @@
+"""Unit tests for the pure / near-pure helpers on ``_AnalysisMixin``.
+
+These methods shape analysis output without driving Origin: some build LabTalk
+variable-name maps (no originpro at all), and ``_structure_scalar_outputs`` only
+needs ``op.lt_float`` to evaluate the variables. The latter is exercised by
+injecting a tiny fake ``op`` onto ``client._op`` so the lazy ``op`` property
+returns it instead of importing the real ``originpro`` package.
+
+This file is the worked example for closing the client-mixin coverage gap; the
+same ``_op`` injection pattern extends to the sheet-building helpers once a
+reusable fake-worksheet fixture exists.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from origin_mcp.origin_client import OriginClient
+
+
+def test_list_fit_functions_is_self_describing() -> None:
+    result = OriginClient().list_fit_functions()
+
+    assert result["count"] == len(result["functions"])
+    names = {fn["name"] for fn in result["functions"]}
+    assert {"Gauss", "Lorentz", "ExpDec1", "Boltzmann"} <= names
+    for fn in result["functions"]:
+        assert fn["parameters"], f"{fn['name']} has no parameters listed"
+
+
+def test_polynomial_output_variables_are_unique_and_complete() -> None:
+    variables = OriginClient._polynomial_output_variables()
+
+    assert set(variables) == {"coef", "err", "N", "AdjRSq", "RSqCOD"}
+    # Distinct LabTalk names with a shared per-call random prefix.
+    assert len(set(variables.values())) == len(variables)
+    prefixes = {name[:8] for name in variables.values()}
+    assert len(prefixes) == 1
+    # Two calls must not collide on the same prefix.
+    assert OriginClient._polynomial_output_variables() != variables
+
+
+def test_moments_output_variables_cover_descriptive_stats() -> None:
+    variables = OriginClient._moments_output_variables()
+
+    assert set(variables) == {
+        "mean",
+        "sd",
+        "se",
+        "n",
+        "sum",
+        "skewness",
+        "kurtosis",
+        "cv",
+    }
+    assert len(set(variables.values())) == len(variables)
+
+
+def test_prepare_scalar_outputs_maps_each_name() -> None:
+    names = ("stat", "prob", "df")
+    variables = OriginClient._prepare_scalar_outputs(names)
+
+    assert set(variables) == set(names)
+    assert len(set(variables.values())) == len(names)
+
+
+class _FakeOp:
+    """Minimal originpro stand-in exposing only ``lt_float``."""
+
+    def __init__(self, values: dict[str, Any]) -> None:
+        self._values = values
+
+    def lt_float(self, expression: str) -> Any:
+        # Mirror originpro: returns the LabTalk variable's float value.
+        return self._values[expression]
+
+
+def test_structure_scalar_outputs_renames_and_filters() -> None:
+    client = OriginClient()
+    variables = {"stat": "v_stat", "prob": "v_prob", "df": "v_df"}
+    # ``prob`` evaluates to a non-finite/missing value and must be dropped.
+    client._op = _FakeOp({"v_stat": 12.5, "v_prob": float("nan"), "v_df": 4.0})
+
+    structured = client._structure_scalar_outputs(variables)
+
+    # Known keys are renamed to their report labels; NaN ``prob`` is filtered out.
+    assert structured["metrics"] == {"Statistic": 12.5, "DF": 4.0}
+    # The raw variable map is preserved for traceability.
+    assert structured["sections"]["scalar_variables"] == variables
+
+
+def test_structure_scalar_outputs_keeps_unknown_keys_verbatim() -> None:
+    client = OriginClient()
+    client._op = _FakeOp({"v_custom": 7.0})
+
+    structured = client._structure_scalar_outputs({"custom": "v_custom"})
+
+    # Unmapped keys fall through unchanged rather than being dropped.
+    assert structured["metrics"] == {"custom": 7.0}
+
+
+# -- sheet-building helpers (need the fake worksheet surface) --------------
+
+
+def test_analysis_output_reads_existing_sheet(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Result", pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+
+    output = fake_client._analysis_output("Result", max_rows=10)
+
+    assert output["total_rows"] == 2
+    assert output["columns"] == ["a", "b"]
+
+
+def test_analysis_output_reports_missing_sheet(fake_client: OriginClient) -> None:
+    output = fake_client._analysis_output("DoesNotExist")
+
+    assert output["found"] is False
+    assert output["output_sheet"] == "DoesNotExist"
+
+
+def test_prepare_report_output_creates_sheet(fake_client: OriginClient) -> None:
+    prepared = fake_client._prepare_report_output("Stats")
+
+    assert prepared["worksheet"].startswith("[")
+    assert prepared["ref"].endswith("!")
+    # A backing sheet now exists in the fake project.
+    assert fake_client.op.books
+
+
+def test_prepare_analysis_xy_output_passthrough_for_explicit_range(
+    fake_client: OriginClient,
+) -> None:
+    # A range that already contains "!" is returned verbatim.
+    assert fake_client._prepare_analysis_xy_output("[Book1]Sheet1!(1,2)") == "[Book1]Sheet1!(1,2)"
+
+
+def test_prepare_peak_find_outputs_builds_columns(fake_client: OriginClient) -> None:
+    prepared = fake_client._prepare_peak_find_outputs("Peaks")
+
+    assert prepared["ocenter"].endswith("!(1)")
+    assert prepared["ocenter_x"].endswith("!(2)")
+    assert prepared["ocenter_y"].endswith("!(3)")

--- a/tests/test_analysis_run.py
+++ b/tests/test_analysis_run.py
@@ -1,0 +1,131 @@
+"""Behavioural tests for ``run_analysis`` dispatch and structured fits."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from fake_origin import FakeLinearFit
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def _seed(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2, 3], "y": [2, 4, 6]}))
+
+
+def test_run_analysis_smooth_executes(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(
+        analysis="smooth", worksheet="Data", x_col="x", y_col="y", output_sheet="Result"
+    )
+
+    assert result["analysis"] == "smooth"
+    assert result["executed"] is True
+    assert "script" in result
+
+
+def test_run_analysis_descriptive_stats(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(analysis="descriptive_stats", worksheet="Data", y_col="y")
+
+    assert result["analysis"] == "descriptive_stats"
+    assert "metrics" in result
+
+
+def test_run_analysis_ttest_scalar_path(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(
+        analysis="ttest_one_sample", worksheet="Data", y_col="y", options={"mean": 0}
+    )
+
+    assert result["analysis"] == "ttest_one_sample"
+    assert result["executed"] is True
+
+
+def test_run_analysis_fft_report_path(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(
+        analysis="fft", worksheet="Data", x_col="x", y_col="y", output_sheet="FFTOut"
+    )
+
+    assert result["analysis"] == "fft"
+    assert result["executed"] is True
+
+
+def test_run_analysis_correlation_report_path(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(
+        analysis="correlation",
+        worksheet="Data",
+        output_sheet="Corr",
+        options={"spearman": True},
+    )
+
+    assert result["analysis"] == "correlation"
+
+
+def test_run_analysis_peak_find_path(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.run_analysis(
+        analysis="peak_find", worksheet="Data", x_col="x", y_col="y", output_sheet="Peaks"
+    )
+
+    assert result["analysis"] == "peak_find"
+
+
+def test_linear_fit_result_result_mode(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+    fake_client.op.LinearFit = FakeLinearFit  # type: ignore[attr-defined]
+
+    result = fake_client.linear_fit_result(worksheet="Data", x_col="x", y_col="y")
+
+    assert result["mode"] == "result"
+    names = {param["name"].lower() for param in result["result"]["parameters"]}
+    assert "slope" in names and "intercept" in names
+
+
+def test_linear_fit_result_report_mode(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+    fake_client.op.LinearFit = FakeLinearFit  # type: ignore[attr-defined]
+
+    result = fake_client.linear_fit_result(
+        worksheet="Data", x_col="x", y_col="y", options={"report": True}
+    )
+
+    assert result["mode"] == "report"
+    assert result["report_sheet"] == "FitReport"
+
+
+def test_linear_fit_result_requires_api(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+    # No LinearFit on the fake op -> ensure_feature raises.
+    with pytest.raises(OriginOperationError):
+        fake_client.linear_fit_result(worksheet="Data", x_col="x", y_col="y")
+
+
+def test_nonlinear_fit_structured_delegates(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+
+    result = fake_client.nonlinear_fit_structured(
+        worksheet="Data",
+        x_col="x",
+        y_col="y",
+        function="Gauss",
+        initial_params={"A": 1.0},
+        fixed_params=["y0"],
+    )
+
+    assert result["analysis"] == "nonlinear_fit"
+
+
+def test_nonlinear_fit_structured_rejects_empty_function(fake_client: OriginClient) -> None:
+    _seed(fake_client)
+    with pytest.raises(OriginOperationError):
+        fake_client.nonlinear_fit_structured(worksheet="Data", x_col="x", y_col="y", function="  ")

--- a/tests/test_graph_mixin.py
+++ b/tests/test_graph_mixin.py
@@ -1,0 +1,251 @@
+"""Behavioural tests for graph creation, formatting, and export.
+
+These drive the graph-object orchestration (plot_table, format_graph, set_axis,
+list_project, export_*) against the in-memory fake graph surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def _write_csv(tmp_path: Path, name: str = "data.csv") -> Path:
+    path = tmp_path / name
+    path.write_text("x,y1,y2\n1,10,100\n2,20,200\n3,30,300\n", encoding="utf-8")
+    return path
+
+
+# -- plot_table orchestration --------------------------------------------
+
+
+def test_plot_table_creates_graph_and_plots(fake_client: OriginClient, tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path)
+
+    worksheet, graph = fake_client.plot_table(
+        path=csv,
+        kind="line",
+        x_col="x",
+        y_cols=["y1", "y2"],
+        graph_name="MyPlot",
+        title="Title",
+        x_label="X axis",
+        y_label="Y axis",
+    )
+
+    assert worksheet.columns == ["x", "y1", "y2"]
+    assert worksheet.rows == 3
+    assert graph.template == "line"
+    # Two Y columns -> two plots in the first layer.
+    page = fake_client.op.graphs[-1]
+    assert len(page[0].plots) == 2
+    # Axis titles were applied via format_graph.
+    assert page[0].axis("x").title == "X axis"
+    assert page[0].axis("y").title == "Y axis"
+
+
+def test_plot_table_exports_when_requested(fake_client: OriginClient, tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path)
+    out = tmp_path / "fig.png"
+
+    _, graph = fake_client.plot_table(
+        path=csv,
+        kind="scatter",
+        x_col="x",
+        y_cols=["y1"],
+        graph_name="Exp",
+        export_path=out,
+    )
+
+    assert graph.export_path is not None
+    assert Path(graph.export_path).exists()
+
+
+def test_plot_table_rejects_empty_file(fake_client: OriginClient, tmp_path: Path) -> None:
+    empty = tmp_path / "empty.csv"
+    empty.write_text("x,y\n", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.plot_table(path=empty, kind="line")
+
+
+# -- list_project ---------------------------------------------------------
+
+
+def test_list_project_classifies_books_and_graphs(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1]}))
+    fake_client.op.add_graph("G1", lname="My Graph")
+
+    project = fake_client.list_project()
+
+    assert len(project["workbooks"]) == 1
+    assert project["workbooks"][0]["name"] == "Data"
+    assert len(project["graphs"]) == 1
+    assert project["graphs"][0]["long_name"] == "My Graph"
+
+
+# -- set_axis -------------------------------------------------------------
+
+
+def test_set_axis_applies_scale_and_limits(fake_client: OriginClient) -> None:
+    fake_client.op.add_graph("G1")
+
+    result = fake_client.set_axis(graph_name="G1", axis="y", scale="log", start=1.0, end=100.0)
+
+    assert result["axis"] == "y"
+    assert result["axis_info"]["scale_name"] == "log10"
+    assert result["axis_info"]["limits"] == (1.0, 100.0, None)
+    assert result["verified"] is True
+
+
+def test_set_axis_unknown_graph_raises(fake_client: OriginClient) -> None:
+    with pytest.raises(OriginOperationError) as excinfo:
+        fake_client.set_axis(graph_name="Missing", axis="x", scale="linear")
+    assert excinfo.value.error_code == "graph_not_found"
+
+
+# -- format_graph ---------------------------------------------------------
+
+
+def test_format_graph_sets_titles_and_rescales(fake_client: OriginClient) -> None:
+    page = fake_client.op.add_graph("G1")
+
+    result = fake_client.format_graph(
+        graph_name="G1", x_label="time", y_label="signal", rescale=True
+    )
+
+    assert result["formatted"] is True
+    assert page[0].axis("x").title == "time"
+    assert page[0].rescaled == 1
+
+
+# -- rename / delete ------------------------------------------------------
+
+
+def test_rename_object(fake_client: OriginClient) -> None:
+    fake_client.op.add_graph("G1")
+
+    result = fake_client.rename_object(name="G1", new_name="Renamed", object_type="graph")
+
+    assert result["new_name"] == "Renamed"
+
+
+def test_delete_object(fake_client: OriginClient) -> None:
+    page = fake_client.op.add_graph("G1")
+
+    result = fake_client.delete_object(name="G1", object_type="graph")
+
+    assert result["deleted"] is True
+    assert page.destroyed is True
+
+
+# -- export ---------------------------------------------------------------
+
+
+def test_export_graph_by_name_uses_labtalk(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.add_graph("G1")
+    out = tmp_path / "g.png"
+
+    result = fake_client.export_graph(path=out, graph_name="G1")
+
+    assert result["path"] == str(out)
+    # The export ran through a LabTalk expGraph command.
+    assert any("expGraph" in script for _, (script, *_rest) in _lt_exec_calls(fake_client))
+
+
+def test_export_graph_refuses_existing(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.add_graph("G1")
+    out = tmp_path / "g.png"
+    out.write_text("x", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.export_graph(path=out, graph_name="G1", overwrite=False)
+
+
+def test_export_all_graphs_writes_files(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.add_graph("Alpha")
+    fake_client.op.add_graph("Beta")
+
+    result = fake_client.export_all_graphs(output_dir=tmp_path, file_type="png")
+
+    assert result["count"] == 2
+    assert all(Path(p).exists() for p in result["paths"])
+
+
+def test_export_preview_returns_inspection(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.add_graph("G1")
+
+    result = fake_client.export_preview(graph_name="G1", output_dir=tmp_path)
+
+    assert Path(result["path"]).exists()
+    assert result["preview"]["exists"] is True
+    assert result["preview"]["width"] == 1
+
+
+def _lt_exec_calls(client: OriginClient) -> list[tuple[str, tuple]]:
+    return [call for call in client.op.calls if call[0] == "lt_exec"]
+
+
+# -- plot editing & introspection ----------------------------------------
+
+
+def test_add_plot_to_graph(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+    page = fake_client.op.add_graph("G1")
+
+    result = fake_client.add_plot_to_graph(worksheet="Data", x_col="x", y_col="y", graph_name="G1")
+
+    assert result["x_col"] == "x"
+    assert result["y_col"] == "y"
+    assert len(page[0].plots) == 1
+
+
+def test_get_graph_info_reports_layers_and_plots(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+    fake_client.op.add_graph("G1", lname="Long")
+    fake_client.add_plot_to_graph(worksheet="Data", x_col="x", y_col="y", graph_name="G1")
+
+    info = fake_client.get_graph_info(graph_name="G1")
+
+    assert info["long_name"] == "Long"
+    assert info["layers_count"] == 1
+    assert info["layers"][0]["plots_count"] == 1
+
+
+def test_get_layer_info(fake_client: OriginClient) -> None:
+    fake_client.op.add_graph("G1")
+
+    info = fake_client.get_layer_info(graph_name="G1", layer_index=0)
+
+    assert info["layer"]["index"] == 0
+    assert "axes" in info["layer"]
+
+
+def test_change_plot_type_issues_command(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+    page = fake_client.op.add_graph("G1")
+    fake_client.add_plot_to_graph(worksheet="Data", x_col="x", y_col="y", graph_name="G1")
+
+    result = fake_client.change_plot_type(plot_index=0, plot_type="s", graph_name="G1")
+
+    assert result["plot_type"] == "s"
+    assert "-c s" in page[0].plots[0].commands
+
+
+def test_change_plot_type_out_of_range(fake_client: OriginClient) -> None:
+    fake_client.op.add_graph("G1")
+    with pytest.raises(OriginOperationError):
+        fake_client.change_plot_type(plot_index=5, plot_type="s", graph_name="G1")
+
+
+def test_remove_plot_from_graph(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+    fake_client.op.add_graph("G1")
+    fake_client.add_plot_to_graph(worksheet="Data", x_col="x", y_col="y", graph_name="G1")
+
+    result = fake_client.remove_plot_from_graph(plot_index=0, graph_name="G1")
+
+    assert result["removed_plot_index"] == 0

--- a/tests/test_lifecycle_mixin.py
+++ b/tests/test_lifecycle_mixin.py
@@ -1,0 +1,139 @@
+"""Behavioural tests for ``_LifecycleMixin`` against the fake Origin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fake_origin import FakeOp
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def test_connect_reports_version_and_show(fake_client: OriginClient) -> None:
+    fake_client.op.lt_values["@V"] = 10.3
+
+    result = fake_client.connect(show=True)
+
+    assert result["connected"] is True
+    assert result["visible"] is True
+    assert result["origin_version"] == 10.3
+    assert fake_client.op.show is True
+
+
+def test_capabilities_are_cached(fake_client: OriginClient) -> None:
+    first = fake_client.capabilities()
+    second = fake_client.capabilities()
+
+    assert first is second  # cached, no recomputation
+    assert "features" in first
+    # The fake exposes lt_exec and pages, so those features read as available.
+    assert first["features"]["labtalk"]["available"] is True
+    assert first["features"]["pages"]["available"] is True
+
+
+def test_capabilities_refresh_recomputes(fake_client: OriginClient) -> None:
+    first = fake_client.capabilities()
+    second = fake_client.capabilities(refresh=True)
+
+    assert first is not second
+
+
+def test_ensure_feature_raises_for_missing(fake_client: OriginClient) -> None:
+    # The fake op has no LinearFit, so linear_fit_api is unavailable.
+    with pytest.raises(OriginOperationError) as excinfo:
+        fake_client.ensure_feature("linear_fit_api", "Structured linear fitting")
+    assert excinfo.value.error_code == "unsupported_origin_feature"
+
+
+def test_new_project_invokes_new(fake_client: OriginClient) -> None:
+    result = fake_client.new_project(show=False)
+
+    assert result["created"] is True
+    assert ("new", ()) in fake_client.op.calls
+
+
+def test_save_project_uses_originpro_save(fake_client: OriginClient, tmp_path: Path) -> None:
+    target = tmp_path / "proj.opju"
+
+    result = fake_client.save_project(path=target)
+
+    assert result["saved"] is True
+    assert result["method"] == "originpro.save"
+    assert any(name == "save" for name, _ in fake_client.op.calls)
+
+
+def test_quit_clears_state(fake_client: OriginClient) -> None:
+    result = fake_client.quit()
+
+    assert result["closed"] is True
+    assert fake_client._op is None
+    assert fake_client._capabilities is None
+
+
+def test_detach_releases_without_closing(fake_client: OriginClient) -> None:
+    result = fake_client.detach()
+
+    assert result == {"detached": True, "closed": False}
+    assert fake_client._op is None
+
+
+def test_run_labtalk_rejects_empty(fake_client: OriginClient) -> None:
+    with pytest.raises(OriginOperationError):
+        fake_client.run_labtalk("   ")
+
+
+def test_run_labtalk_warns_on_false_result(fake_client: OriginClient) -> None:
+    fake_client.op.lt_exec_result = False
+
+    response = fake_client.run_labtalk("bad_command;")
+
+    assert response["result"] is False
+    assert "warning" in response
+
+
+def test_run_labtalk_unavailable_without_lt_exec() -> None:
+    op = FakeOp()
+    # Remove lt_exec to simulate an environment without LabTalk execution.
+    op.lt_exec = None  # type: ignore[assignment]
+    client = OriginClient()
+    client._op = op
+    with pytest.raises(OriginOperationError) as excinfo:
+        client.run_labtalk("foo;")
+    assert excinfo.value.error_code == "labtalk_unavailable"
+
+
+def test_run_labtalk_capture_log(fake_client: OriginClient) -> None:
+    response = fake_client.run_labtalk("type test;", capture_log=True)
+
+    assert "result" in response
+    assert "message_log" in response
+
+
+def test_open_project(fake_client: OriginClient, tmp_path: Path) -> None:
+    project = tmp_path / "p.opju"
+    project.write_bytes(b"opju")
+
+    result = fake_client.open_project(path=project)
+
+    assert result["opened"] is True
+    assert any(name == "open" for name, _ in fake_client.op.calls)
+
+
+def test_open_project_rejects_non_project_file(fake_client: OriginClient, tmp_path: Path) -> None:
+    bad = tmp_path / "p.txt"
+    bad.write_text("x", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.open_project(path=bad)
+
+
+def test_save_project_falls_back_to_pe_save(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.save_raises = True
+    target = tmp_path / "p.opju"
+
+    result = fake_client.save_project(path=target)
+
+    assert result["saved"] is True
+    assert result["method"] == "labtalk.pe_save"
+    assert "fallback_error" in result

--- a/tests/test_plot_routing.py
+++ b/tests/test_plot_routing.py
@@ -1,0 +1,120 @@
+"""Behavioural tests for chart routing and range/template plotting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def _xy_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    path.write_text("x,y1,y2\n1,4,9\n2,5,8\n3,6,7\n", encoding="utf-8")
+    return path
+
+
+# -- recommend_chart / chart_atlas_route (pure routing) -------------------
+
+
+def test_recommend_chart_returns_selection(fake_client: OriginClient, tmp_path: Path) -> None:
+    result = fake_client.recommend_chart(path=_xy_csv(tmp_path))
+
+    assert "selected" in result
+    assert "candidates" in result
+    assert result["candidates"]
+
+
+def test_recommend_chart_rejects_empty(fake_client: OriginClient, tmp_path: Path) -> None:
+    empty = tmp_path / "empty.csv"
+    empty.write_text("x,y\n", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.recommend_chart(path=empty)
+
+
+def test_chart_atlas_route_resolves_intent(fake_client: OriginClient) -> None:
+    route = fake_client.chart_atlas_route(intent="correlation", columns=["x", "y"])
+
+    assert route["intent"]
+    assert route["input_columns"] == ["x", "y"]
+
+
+def test_chart_atlas_route_warns_on_matrix_misroute(fake_client: OriginClient) -> None:
+    route = fake_client.chart_atlas_route(intent="correlation", columns=["x"], matrix=True)
+
+    assert route.get("warnings")
+
+
+# -- plot_range / batch ---------------------------------------------------
+
+
+def test_plot_range_creates_plot(fake_client: OriginClient) -> None:
+    graph = fake_client.plot_range(
+        data_range="[Book1]Sheet1!(1,2)", template="line", graph_name="R1", title="T"
+    )
+
+    assert graph.graph_name
+    page = fake_client.op.graphs[-1]
+    assert len(page[0].plots) == 1
+
+
+def test_plot_range_rejects_empty_range(fake_client: OriginClient) -> None:
+    with pytest.raises(OriginOperationError):
+        fake_client.plot_range(data_range="   ")
+
+
+def test_batch_plot_from_template(fake_client: OriginClient, tmp_path: Path) -> None:
+    result = fake_client.batch_plot_from_template(
+        data_ranges=["[Book1]Sheet1!(1,2)", "[Book1]Sheet1!(1,3)"],
+        template="line",
+        output_dir=tmp_path,
+    )
+
+    assert result["count"] == 2
+    assert all(Path(g["export_path"]).exists() for g in result["graphs"])
+
+
+# -- list_graph_templates -------------------------------------------------
+
+
+def test_list_graph_templates_builtin(fake_client: OriginClient) -> None:
+    result = fake_client.list_graph_templates()
+
+    assert "line" in result["builtin"]
+    assert "ternary" in result["builtin"]
+    assert result["discovered"] == []
+
+
+def test_list_graph_templates_discovers_files(fake_client: OriginClient, tmp_path: Path) -> None:
+    (tmp_path / "custom.otp").write_bytes(b"tmpl")
+    (tmp_path / "ignored.txt").write_text("x", encoding="utf-8")
+
+    result = fake_client.list_graph_templates(template_dir=tmp_path)
+
+    names = {entry["name"] for entry in result["discovered"]}
+    assert names == {"custom"}
+
+
+def test_list_graph_templates_missing_dir(fake_client: OriginClient, tmp_path: Path) -> None:
+    with pytest.raises(OriginOperationError):
+        fake_client.list_graph_templates(template_dir=tmp_path / "nope")
+
+
+# -- plot_table_by_id (plotxy route) -------------------------------------
+
+
+def test_plot_table_by_id_plotxy_route(fake_client: OriginClient, tmp_path: Path) -> None:
+    worksheet, graph, command = fake_client.plot_table_by_id(
+        path=_xy_csv(tmp_path),
+        plot_type_id=200,
+        template="line",
+        selected_cols=["x", "y1"],
+        graph_name="ById",
+    )
+
+    assert worksheet.columns == ["x", "y1", "y2"]
+    assert command["command"] == "plotxy"
+    assert command["plot_type_id"] == 200
+    assert graph.template == "line"

--- a/tests/test_table_plot_helpers.py
+++ b/tests/test_table_plot_helpers.py
@@ -1,0 +1,97 @@
+"""Unit tests for the pure command-building helpers on ``_TablePlotMixin``.
+
+The full plot path drives Origin's graphing engine, but the LabTalk command
+construction and route-selection logic are pure functions worth pinning down on
+their own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from origin_mcp.client.base import TABLE_PLOTXYZ_IDS, TABLE_WORKSHEET_PLOT_IDS
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def test_table_plot_command_options_routes_by_id() -> None:
+    worksheet_id = next(iter(TABLE_WORKSHEET_PLOT_IDS))
+    plotxyz_id = next(iter(TABLE_PLOTXYZ_IDS))
+
+    assert OriginClient._table_plot_command_options(worksheet_id) == ("worksheet", "selection")
+    assert OriginClient._table_plot_command_options(plotxyz_id) == ("plotxyz", "iz")
+    # 200 is a plain XY line plot id, not in either special set.
+    assert OriginClient._table_plot_command_options(200) == ("plotxy", "iy")
+
+
+def test_plot_command_output_warning_only_on_mismatch() -> None:
+    assert OriginClient._plot_command_output_warning(None, "G") is None
+    assert OriginClient._plot_command_output_warning("G", "G") is None
+    warning = OriginClient._plot_command_output_warning("Requested", "Actual")
+    assert warning is not None and "Requested" in warning and "Actual" in warning
+
+
+def test_plot_rejected_message_includes_context() -> None:
+    message = OriginClient._plot_rejected_message(200, "line", ["A", "B"], "plotxy ...;")
+
+    assert "200" in message
+    assert "line" in message
+    assert "['A', 'B']" in message
+
+
+def test_worksheet_plot_command_requires_contiguous_selection() -> None:
+    columns = ["x", "y1", "y2"]
+
+    script = OriginClient._worksheet_plot_command(columns, ["x", "y1"], 100, "tmpl")
+    assert "worksheet -s 1 0 2 0;" in script
+    assert "worksheet -p 100 tmpl;" in script
+
+    with pytest.raises(OriginOperationError):
+        OriginClient._worksheet_plot_command(columns, ["x", "y2"], 100, "tmpl")
+
+
+@pytest.mark.parametrize(
+    ("plot_type_id", "count", "expected"),
+    [
+        (183, 6, (4, 1, 6, 4, 1, 6)),
+        (184, 4, (4, 1, 6, 6)),
+        (200, 3, (4, 1, 6)),
+        (183, 3, (4, 1, 6)),  # too few selected -> default pattern
+    ],
+)
+def test_plotxyz_type_pattern(plot_type_id: int, count: int, expected: tuple[int, ...]) -> None:
+    assert OriginClient._plotxyz_type_pattern(plot_type_id, count) == expected
+
+
+def test_plotxyz_axis_spec_maps_types() -> None:
+    assert OriginClient._plotxyz_axis_spec((4, 1, 6)) == "XYZ"
+    assert OriginClient._plotxyz_axis_spec((4, 1, 6, 6)) == "XYZZ"
+
+
+def test_resolve_graph_template_prefers_explicit() -> None:
+    client = OriginClient()
+    assert client._resolve_graph_template("scatter") == "scatter"
+    assert client._resolve_graph_template("scatter", template="custom") == "custom"
+    # Unknown kind falls back to "line".
+    assert client._resolve_graph_template("nonexistent-kind") == "line"
+
+
+def test_plot_command_new_vs_reuse() -> None:
+    new_script = OriginClient._plot_command(
+        "plotxy", "iy", "[Book1]Sheet1!(1,2)", 200, "line", "MyGraph"
+    )
+    assert "plotxy iy:=[Book1]Sheet1!(1,2)" in new_script
+    assert "plot:=200" in new_script
+    assert "name:=MyGraph" in new_script
+
+    reuse_script = OriginClient._plot_command(
+        "plotxy", "iy", "[Book1]Sheet1!(1,2)", 200, "line", "MyGraph", reuse_existing=True
+    )
+    assert "ogl:=[MyGraph]1" in reuse_script
+
+
+def test_assert_plot_type_command_detects_route_mismatch() -> None:
+    client = OriginClient()
+    # 200 should route through plotxy/iy; claiming worksheet is a mismatch.
+    with pytest.raises(OriginOperationError):
+        client._assert_plot_type_command(200, "line", "worksheet", "selection", "worksheet -p ...")

--- a/tests/test_transform_mixin.py
+++ b/tests/test_transform_mixin.py
@@ -1,0 +1,150 @@
+"""Behavioural tests for the pandas-backed data-transform methods."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+
+def test_filter_rows_combines_and(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2, 3, 4], "g": ["a", "a", "b", "b"]}))
+
+    result = fake_client.filter_rows(
+        conditions=[{"column": "x", "op": "gt", "value": 1}, {"column": "g", "value": "a"}],
+        combine="and",
+    )
+
+    assert result["matched_rows"] == 1
+    assert result["total_rows"] == 4
+
+
+def test_filter_rows_requires_conditions(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.filter_rows(conditions=[])
+
+
+def test_drop_duplicates_removes_repeats(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 1, 2], "y": [9, 9, 8]}))
+
+    result = fake_client.drop_duplicates()
+
+    assert result["removed_rows"] == 1
+    assert result["total_rows"] == 3
+
+
+def test_fill_missing_with_value(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1.0, None, 3.0]}))
+
+    result = fake_client.fill_missing(strategy="value", value=0)
+
+    assert result["strategy"] == "value"
+    sheet = fake_client.op.find_sheet("w", "Data")
+    assert sheet is not None and sheet.to_df()["x"].tolist() == [1.0, 0.0, 3.0]
+
+
+def test_fill_missing_value_requires_value(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1.0, None]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.fill_missing(strategy="value", value=None)
+
+
+def test_fill_missing_mean(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [2.0, None, 4.0]}))
+
+    fake_client.fill_missing(strategy="mean")
+
+    sheet = fake_client.op.find_sheet("w", "Data")
+    assert sheet is not None and sheet.to_df()["x"].tolist() == [2.0, 3.0, 4.0]
+
+
+def test_fill_missing_rejects_unknown_strategy(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1.0, None]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.fill_missing(strategy="bogus")
+
+
+def test_transpose_worksheet_with_label_column(fake_client: OriginClient) -> None:
+    fake_client.op.add_book(
+        "Data", pd.DataFrame({"name": ["m1", "m2"], "v1": [1, 2], "v2": [3, 4]})
+    )
+
+    result = fake_client.transpose_worksheet(label_column="name", output_sheet="T")
+
+    cols = result["worksheet"]["columns"]
+    assert cols[0] == "Field"
+    assert "m1" in cols and "m2" in cols
+
+
+def test_merge_worksheets_inner_join(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Left", pd.DataFrame({"id": [1, 2], "a": [10, 20]}))
+    fake_client.op.add_book("Right", pd.DataFrame({"id": [2, 3], "b": [200, 300]}))
+
+    result = fake_client.merge_worksheets(
+        book_name="Left",
+        right_book="Right",
+        on="id",
+        how="inner",
+        output_book="Merged",
+    )
+
+    assert result["how"] == "inner"
+    assert result["result_rows"] == 1
+
+
+def test_merge_worksheets_rejects_bad_how(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Left", pd.DataFrame({"id": [1]}))
+    fake_client.op.add_book("Right", pd.DataFrame({"id": [1]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.merge_worksheets(book_name="Left", right_book="Right", on="id", how="diagonal")
+
+
+def test_concat_worksheets_rows(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("A", pd.DataFrame({"x": [1, 2]}))
+    fake_client.op.add_book("B", pd.DataFrame({"x": [3]}))
+
+    result = fake_client.concat_worksheets(
+        others=[{"book": "B"}],
+        axis="rows",
+        book_name="A",
+        output_book="Combined",
+    )
+
+    assert result["result_rows"] == 3
+    assert result["combined_sheets"] == 2
+
+
+def test_concat_worksheets_rejects_bad_axis(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("A", pd.DataFrame({"x": [1]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.concat_worksheets(others=[{"book": "A"}], axis="depth", book_name="A")
+
+
+def test_pivot_worksheet(fake_client: OriginClient) -> None:
+    df = pd.DataFrame(
+        {
+            "row": ["r1", "r1", "r2"],
+            "col": ["c1", "c2", "c1"],
+            "val": [1.0, 2.0, 3.0],
+        }
+    )
+    fake_client.op.add_book("Data", df)
+
+    result = fake_client.pivot_worksheet(
+        index="row", columns="col", values="val", aggfunc="mean", output_sheet="P"
+    )
+
+    assert result["aggfunc"] == "mean"
+    assert "row" in result["worksheet"]["columns"]
+
+
+def test_melt_worksheet(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [30, 40]}))
+
+    result = fake_client.melt_worksheet(id_vars=["id"], value_vars=["a", "b"])
+
+    assert set(result["worksheet"]["columns"]) == {"id", "variable", "value"}
+    assert result["worksheet"]["rows"] == 4

--- a/tests/test_worksheet_mixin.py
+++ b/tests/test_worksheet_mixin.py
@@ -1,0 +1,279 @@
+"""Behavioural tests for ``_WorksheetMixin`` against the in-memory fake Origin.
+
+These exercise the pandas round-trip logic (read/write/sort/cells/transforms)
+that previously only ran under live Origin validation.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from fake_origin import FakeOp
+
+from origin_mcp.errors import OriginOperationError
+from origin_mcp.origin_client import OriginClient
+
+# -- read / write ---------------------------------------------------------
+
+
+def test_read_worksheet_windows_rows(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    result = fake_client.read_worksheet(start_row=1, max_rows=2)
+
+    assert result["total_rows"] == 4
+    assert result["returned_rows"] == 2
+    assert result["columns"] == ["x", "y"]
+    assert [row["x"] for row in result["rows"]] == [2, 3]
+
+
+def test_read_worksheet_selects_columns(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    result = fake_client.read_worksheet(columns=["y"])
+
+    assert result["columns"] == ["y"]
+    assert all(set(row) == {"y"} for row in result["rows"])
+
+
+@pytest.mark.parametrize("kwargs", [{"start_row": -1}, {"max_rows": 0}])
+def test_read_worksheet_validates_bounds(
+    fake_client: OriginClient, sample_df: pd.DataFrame, kwargs: dict[str, int]
+) -> None:
+    fake_client.op.add_book("Data", sample_df)
+    with pytest.raises(OriginOperationError):
+        fake_client.read_worksheet(**kwargs)
+
+
+def test_write_worksheet_creates_and_trims(fake_client: OriginClient) -> None:
+    # Seed a wider sheet so writing a narrower frame must trim trailing columns.
+    fake_client.op.add_book("Out", pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
+
+    result = fake_client.write_worksheet(
+        rows=[{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+        book_name="Out",
+    )
+
+    assert result["worksheet"]["columns"] == ["a", "b"]
+    sheet = fake_client.op.find_sheet("w", "Out")
+    assert sheet is not None and list(sheet.to_df().columns) == ["a", "b"]
+
+
+def test_write_worksheet_rejects_empty(fake_client: OriginClient) -> None:
+    with pytest.raises(OriginOperationError):
+        fake_client.write_worksheet(rows=[], create=True)
+
+
+def test_worksheet_info_reports_columns(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    info = fake_client.worksheet_info()
+
+    assert info["columns_count"] == 2
+    assert info["rows"] == 4
+    assert info["labels"]["L"] == ["x", "y"]
+
+
+def test_sort_worksheet_orders_descending(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [3, 1, 2], "y": [1, 2, 3]}))
+
+    result = fake_client.sort_worksheet(by="x", ascending=False)
+
+    assert result["sorted_by"] == "x"
+    sheet = fake_client.op.find_sheet("w", "Data")
+    assert sheet is not None and sheet.to_df()["x"].tolist() == [3, 2, 1]
+
+
+# -- cells ----------------------------------------------------------------
+
+
+def test_get_cell_value_reads(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    result = fake_client.get_cell_value(row=2, column="y")
+
+    assert result["column"] == "y"
+    assert result["value"] == 30.0
+
+
+def test_get_cell_value_out_of_range(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+    with pytest.raises(OriginOperationError):
+        fake_client.get_cell_value(row=99, column=0)
+
+
+def test_set_cell_value_writes(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    fake_client.set_cell_value(row=0, column="x", value=999)
+
+    sheet = fake_client.op.find_sheet("w", "Data")
+    assert sheet is not None and sheet.to_df()["x"].tolist()[0] == 999
+
+
+def test_get_cell_value_returns_none_for_nan(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [math.nan, 2.0]}))
+
+    result = fake_client.get_cell_value(row=0, column="x")
+
+    assert result["value"] is None
+
+
+# -- structural edits -----------------------------------------------------
+
+
+def test_delete_columns_removes(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"a": [1], "b": [2], "c": [3]}))
+
+    result = fake_client.delete_columns(columns=["b"])
+
+    assert result["deleted_columns"] == ["b"]
+    assert result["worksheet"]["columns"] == ["a", "c"]
+
+
+def test_clear_worksheet_keeps_columns(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    result = fake_client.clear_worksheet(keep_columns=True)
+
+    assert result["kept_columns"] is True
+    assert result["worksheet"]["columns"] == ["x", "y"]
+    assert result["worksheet"]["rows"] == 0
+
+
+def test_clear_worksheet_drops_columns(fake_client: OriginClient, sample_df: pd.DataFrame) -> None:
+    fake_client.op.add_book("Data", sample_df)
+
+    result = fake_client.clear_worksheet(keep_columns=False)
+
+    assert result["worksheet"]["columns"] == []
+
+
+def test_diagnose_worksheet_flags_missing_and_constant(fake_client: OriginClient) -> None:
+    df = pd.DataFrame(
+        {
+            "all_null": [math.nan, math.nan, math.nan],
+            "constant": [5, 5, 5],
+            "label": ["a", "b", "c"],
+        }
+    )
+    fake_client.op.add_book("Data", df)
+
+    report = fake_client.diagnose_worksheet()
+
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "all_null_column" in codes
+    assert "non_numeric_column" in codes
+
+
+# -- export ---------------------------------------------------------------
+
+
+def test_export_worksheet_csv(
+    fake_client: OriginClient, sample_df: pd.DataFrame, tmp_path: Path
+) -> None:
+    fake_client.op.add_book("Data", sample_df)
+    out = tmp_path / "export.csv"
+
+    result = fake_client.export_worksheet_csv(path=out)
+
+    assert Path(result["path"]).exists()
+    assert result["rows"] == 4
+    written = pd.read_csv(out)
+    assert list(written.columns) == ["x", "y"]
+
+
+def test_export_worksheet_csv_refuses_overwrite(
+    fake_client: OriginClient, sample_df: pd.DataFrame, tmp_path: Path
+) -> None:
+    fake_client.op.add_book("Data", sample_df)
+    out = tmp_path / "export.csv"
+    out.write_text("existing", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.export_worksheet_csv(path=out, overwrite=False)
+
+
+# -- import (file -> worksheet) ------------------------------------------
+
+
+def test_import_table_loads_csv(fake_client: OriginClient, tmp_path: Path) -> None:
+    csv = tmp_path / "in.csv"
+    csv.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+
+    ref = fake_client.import_table(path=csv, book_name="Imported")
+
+    assert ref.columns == ["a", "b"]
+    assert ref.rows == 2
+
+
+def test_import_table_rejects_empty_file(fake_client: OriginClient, tmp_path: Path) -> None:
+    csv = tmp_path / "empty.csv"
+    csv.write_text("a,b\n", encoding="utf-8")
+    with pytest.raises(OriginOperationError):
+        fake_client.import_table(path=csv)
+
+
+# -- worksheet_not_found path --------------------------------------------
+
+
+def test_find_sheet_missing_raises() -> None:
+    client = OriginClient()
+    client._op = FakeOp()  # no books
+    with pytest.raises(OriginOperationError) as excinfo:
+        client.read_worksheet(book_name="Nope", sheet_name="Sheet1")
+    assert excinfo.value.error_code == "worksheet_not_found"
+
+
+# -- calculated columns & labels -----------------------------------------
+
+
+def test_append_table_extends_sheet(fake_client: OriginClient, tmp_path: Path) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"a": [1], "b": [2]}))
+    extra = tmp_path / "more.csv"
+    extra.write_text("c,d\n5,6\n", encoding="utf-8")
+
+    ref = fake_client.append_table(path=extra, book_name="Data", start_col=2)
+
+    assert ref.columns == ["c", "d"]
+
+
+def test_add_calculated_column(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2]}))
+
+    result = fake_client.add_calculated_column(
+        column_name="z", formula="col(x)*2", book_name="Data"
+    )
+
+    assert result["column_name"] == "z"
+    assert result["formula"] == "col(x)*2"
+    sheet = fake_client.op.find_sheet("w", "Data")
+    assert sheet is not None and "z" in sheet.to_df().columns
+
+
+def test_add_calculated_columns_validates_specs(fake_client: OriginClient) -> None:
+    fake_client.op.add_book("Data", pd.DataFrame({"x": [1, 2]}))
+    with pytest.raises(OriginOperationError):
+        fake_client.add_calculated_columns(columns=[{"name": "z"}], book_name="Data")
+
+
+def test_set_column_labels_records(fake_client: OriginClient) -> None:
+    sheet = fake_client.op.add_book("Data", pd.DataFrame({"x": [1], "y": [2]}))
+
+    fake_client.set_column_labels(labels=["Time", "Signal"], label_type="L", book_name="Data")
+
+    assert sheet.label_calls
+    applied_labels, label_type, _offset = sheet.label_calls[0]
+    assert applied_labels == ["Time", "Signal"]
+    assert label_type == "L"
+
+
+def test_set_column_designations_records(fake_client: OriginClient) -> None:
+    sheet = fake_client.op.add_book("Data", pd.DataFrame({"x": [1], "y": [2]}))
+
+    fake_client.set_column_designations(spec="XY", book_name="Data")
+
+    assert sheet.designation_calls
+    assert sheet.designation_calls[0][0] == "XY"


### PR DESCRIPTION
## What

Adds mocked-Origin unit tests for the `OriginClient` mixins and makes the package version single-sourced.

### Test coverage
Introduces an in-memory `originpro` fake (`tests/fake_origin.py`) and a shared fixture (`tests/conftest.py`) so the worksheet, transform, analysis, lifecycle, graph, export, and plot-routing logic can run without a live Origin install (the fake injects via `client._op`, short-circuiting the lazy `op` import).

- **+119 tests** (375 → 494), all green
- **Overall coverage 77% → 81.34%**, CI gate raised 75% → 80%
- Per-module gains: `analysis` 53→87, `export` 72→87, `worksheet` 61→76, `plot_routing` 68→79, `lifecycle` 58→73, `graph_formatting` 61→72

### Version single-sourcing
`pyproject.toml` now uses hatchling `dynamic = ["version"]` reading from `src/origin_mcp/__init__.py`, so the packaged metadata can no longer drift from the version the bridge reports over its ping handshake.

## Scope / risk

**No production code changed** — only new test files plus `pyproject.toml` and `.github/workflows/ci.yml`. The fakes verify pure logic and orchestration; they intentionally do not exercise the real originpro API, so live-Origin validation is still the source of truth for actual plot rendering/styling.

`table_plot.py` (61%) is the remaining gap — its worksheet-route / dual-Y / surface-from-XYZ / matrix paths need a stateful fake and are better confirmed on real Origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
