### PR TITLE
Review follow-ups: unify bridge caching, auto-register tools, tighten mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,18 +80,14 @@ explicit_package_bases = true
 
 [[tool.mypy.overrides]]
 # OriginClient is assembled from cooperating mixins (_TablePlotMixin,
-# _GraphStyleMixin, ...) that call across one another and into the dynamically
-# typed originpro API. Checking each mixin in isolation produces false
-# "has no attribute" positives, and the heavy originpro `Any` interaction makes
-# precise return/argument typing low-value here. Relax this package as part of
-# the lenient baseline; type enforcement focuses on the rest of the codebase.
+# _GraphStyleMixin, ...) that call across one another, so checking each mixin in
+# isolation produces false "has no attribute" positives (attr-defined). The
+# remaining "misc" suppressions cover a generator-typing quirk where len() over
+# the dynamically typed originpro plot list reads as bool. Every other error
+# code is now enforced on this package; only these two stay relaxed.
 module = "origin_mcp.client.*"
 disable_error_code = [
   "attr-defined",
-  "return-value",
-  "arg-type",
-  "assignment",
-  "union-attr",
   "misc",
 ]
 

--- a/src/origin_mcp/bridge_client.py
+++ b/src/origin_mcp/bridge_client.py
@@ -229,17 +229,25 @@ class OriginBridgeClient:
 
 
 class OriginBridgeProxy:
-    """Proxy object with OriginClient-like methods backed by the bridge."""
+    """Proxy object with OriginClient-like methods backed by the bridge.
+
+    The proxy holds only its config and resolves the socket from the shared
+    client pool on each call rather than owning a private ``OriginBridgeClient``.
+    This keeps a single source of truth for live connections: a bridge shutdown
+    (``request_bridge("shutdown")`` -> ``close_shared_bridge_clients``) discards
+    the pooled socket, and the proxy's next call transparently reconnects a fresh
+    one instead of clinging to a stale connection.
+    """
 
     def __init__(self, config: OriginBridgeConfig | None = None) -> None:
-        self._client = OriginBridgeClient(config)
+        self._config = config or OriginBridgeConfig.from_env()
 
     def __getattr__(self, name: str) -> Any:
         if name.startswith("_"):
             raise AttributeError(name)
 
         def call(*args: Any, **kwargs: Any) -> Any:
-            response = self._client.request(
+            response = _shared_client(self._config).request(
                 "call_client",
                 {
                     "method": name,

--- a/src/origin_mcp/client/graph_formatting_helpers.py
+++ b/src/origin_mcp/client/graph_formatting_helpers.py
@@ -188,7 +188,7 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
             "polar": "?",
         }
         plot_type = plot_types.get(kind, "?")
-        attempts = [
+        attempts: list[dict[str, Any]] = [
             {
                 "coly": y_name,
                 "colx": x_name,
@@ -324,6 +324,9 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
             legend.set_int("top", int(top))
             return {"mode": "page_pixel", "left": left, "top": top}
 
+        # Reached only when left and top are both None, so the top-of-function
+        # guard guarantees position is set.
+        assert position is not None
         normalized = position.strip().lower().replace("-", "_")
         aliases = {
             "upper_left": "inside_upper_left",
@@ -684,10 +687,7 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
     def _layer_labels(layer: Any) -> list[dict[str, Any]]:
         labels: list[dict[str, Any]] = []
         layer_labels = getattr(layer, "labels", None)
-        if isinstance(layer_labels, dict):
-            iterable = layer_labels.items()
-        else:
-            iterable = []
+        iterable: list[Any] = list(layer_labels.items()) if isinstance(layer_labels, dict) else []
         for name, label in iterable:
             label_name = _OriginClientBase._object_name(label, default=str(name))
             labels.append(

--- a/src/origin_mcp/client/graph_style.py
+++ b/src/origin_mcp/client/graph_style.py
@@ -659,7 +659,8 @@ class _GraphStyleMixin(_OriginClientBase):
 
     @staticmethod
     def _diagnostic_penalty(issue: dict[str, Any]) -> int:
-        return {"error": 35, "warning": 15, "info": 5}.get(issue.get("severity"), 0)
+        severity = str(issue.get("severity") or "")
+        return {"error": 35, "warning": 15, "info": 5}.get(severity, 0)
 
     @staticmethod
     def _has_meaningful_label(value: Any) -> bool:

--- a/src/origin_mcp/client/table_plot.py
+++ b/src/origin_mcp/client/table_plot.py
@@ -36,7 +36,7 @@ class _TablePlotMixin(_OriginClientBase):
         style_mode: str = "origin_default",
         palette_name: str | None = None,
         export_path: Path | None = None,
-    ) -> tuple[WorksheetRef, GraphRef, dict[str, Any]]:
+    ) -> tuple[WorksheetRef, GraphRef]:
         return self.plot_table(
             path=path,
             kind=kind,
@@ -285,7 +285,7 @@ class _TablePlotMixin(_OriginClientBase):
         style_mode: str = "origin_default",
         palette_name: str | None = None,
         export_path: Path | None = None,
-    ) -> tuple[WorksheetRef, GraphRef]:
+    ) -> tuple[WorksheetRef, GraphRef, dict[str, Any]]:
         path = self._normalize_user_path(path)
         self._validate_file(path)
         df = self._read_table(

--- a/src/origin_mcp/client/worksheet.py
+++ b/src/origin_mcp/client/worksheet.py
@@ -1140,8 +1140,8 @@ class _WorksheetMixin(_OriginClientBase):
         if wks is None and worksheet:
             clean = worksheet.strip()
             if clean.startswith("[") and "]" in clean:
-                book_name, sheet_name = clean[1:].split("]", 1)
-                sheet_name = sheet_name.split("!", 1)[0].strip() or None
+                book_name, raw_sheet = clean[1:].split("]", 1)
+                sheet_name = raw_sheet.split("!", 1)[0].strip() or None
                 wks = self._find_sheet_by_book_label(book_name, sheet_name)
             else:
                 wks = self._find_sheet_by_book_label(clean, None)

--- a/src/origin_mcp/server.py
+++ b/src/origin_mcp/server.py
@@ -1,6 +1,10 @@
 # ruff: noqa: F401
 from __future__ import annotations
 
+import importlib
+import pkgutil
+
+from . import tools
 from .tools._shared import (
     COMPACT_TOOL_NAMES,
     FULL_TOOL_PROFILE_VALUES,
@@ -14,204 +18,36 @@ from .tools._shared import (
     client,
     mcp,
 )
-from .tools.analysis import (
-    origin_correlation,
-    origin_descriptive_stats,
-    origin_differentiate,
-    origin_fft,
-    origin_ifft,
-    origin_integrate,
-    origin_interpolate,
-    origin_linear_fit,
-    origin_list_fit_functions,
-    origin_nonlinear_fit,
-    origin_nonlinear_fit_structured,
-    origin_normalize,
-    origin_peak_find,
-    origin_polynomial_fit,
-    origin_run_analysis,
-    origin_smooth,
-    origin_ttest_one_sample,
-    origin_ttest_paired,
-    origin_ttest_two_sample,
-)
-from .tools.bridge import (
-    origin_bridge_cancel_task,
-    origin_bridge_capabilities,
-    origin_bridge_export_graph,
-    origin_bridge_get_worksheet_info,
-    origin_bridge_import_table,
-    origin_bridge_list_project,
-    origin_bridge_list_tasks,
-    origin_bridge_new_project,
-    origin_bridge_open_project,
-    origin_bridge_ping_origin,
-    origin_bridge_plot_table,
-    origin_bridge_read_worksheet,
-    origin_bridge_run_analysis,
-    origin_bridge_run_labtalk,
-    origin_bridge_save_project,
-    origin_bridge_shutdown,
-    origin_bridge_status,
-    origin_bridge_submit_task,
-    origin_bridge_task_status,
-    origin_bridge_write_worksheet,
-    origin_capabilities,
-    origin_doctor,
-    origin_ping,
-)
-from .tools.figurespec import (
-    origin_execute_figure_spec,
-    origin_plan_figure_spec,
-)
-from .tools.graph import (
-    origin_add_graph_label,
-    origin_add_inset,
-    origin_add_plot_to_graph,
-    origin_add_reference_line,
-    origin_apply_image_panel_style,
-    origin_apply_nature_style,
-    origin_arrange_layers,
-    origin_change_plot_data,
-    origin_change_plot_type,
-    origin_delete_object,
-    origin_diagnose_graph,
-    origin_export_all_graphs,
-    origin_export_graph,
-    origin_export_preview,
-    origin_format_graph,
-    origin_format_legend,
-    origin_get_graph_info,
-    origin_get_layer_info,
-    origin_inspect_export,
-    origin_list_graph_templates,
-    origin_list_project,
-    origin_palette_catalog,
-    origin_plot_style_capabilities,
-    origin_plot_style_setter_coverage,
-    origin_remove_plot_from_graph,
-    origin_rename_object,
-    origin_set_axis,
-    origin_set_axis_break,
-    origin_set_column_designations,
-    origin_set_column_labels,
-    origin_set_graph_page,
-    origin_set_plot_property,
-    origin_set_plot_style,
-    origin_view_graph,
-)
-from .tools.knowledge import (
-    origin_browse_knowledge,
-    origin_browse_labtalk,
-    origin_browse_mcp_tools,
-    origin_browse_official_docs,
-    origin_browse_python_api,
-    origin_browse_reference,
-    origin_plot_type_coverage,
-    origin_query_knowledge,
-    origin_query_labtalk,
-    origin_query_mcp_tools,
-    origin_query_official_docs,
-    origin_query_python_api,
-    origin_query_reference,
-)
-from .tools.lifecycle import (
-    origin_detach,
-    origin_force_quit,
-    origin_quit,
-    origin_release,
-    origin_run_labtalk,
-)
-from .tools.plotting import (
-    _plot_csv,
-    _plot_table_id,
-    _pti,
-    origin_batch_plot_from_template,
-    origin_chart_atlas_route,
-    origin_plot,
-    origin_plot_3d_bars,
-    origin_plot_3d_errorbar,
-    origin_plot_3d_ribbon,
-    origin_plot_3d_scatter,
-    origin_plot_3d_surface,
-    origin_plot_3d_vector,
-    origin_plot_area,
-    origin_plot_auto,
-    origin_plot_bar,
-    origin_plot_box,
-    origin_plot_bubble,
-    origin_plot_bubble_color_mapped,
-    origin_plot_candlestick,
-    origin_plot_chart_atlas,
-    origin_plot_color_mapped,
-    origin_plot_column,
-    origin_plot_column_stack,
-    origin_plot_contour,
-    origin_plot_dendrogram,
-    origin_plot_dual_y,
-    origin_plot_errorbar,
-    origin_plot_fill_area,
-    origin_plot_floating_bar,
-    origin_plot_from_range,
-    origin_plot_heatmap,
-    origin_plot_high_low_close,
-    origin_plot_histogram,
-    origin_plot_image,
-    origin_plot_line,
-    origin_plot_line_symbol,
-    origin_plot_matrix_3d_scatter,
-    origin_plot_matrix_3d_surface,
-    origin_plot_matrix_contour,
-    origin_plot_matrix_heatmap,
-    origin_plot_matrix_id,
-    origin_plot_pie,
-    origin_plot_polar,
-    origin_plot_polar_xr_ytheta,
-    origin_plot_scatter,
-    origin_plot_smith,
-    origin_plot_stack_area,
-    origin_plot_stack_bar,
-    origin_plot_table_id,
-    origin_plot_ternary,
-    origin_plot_ternary_contour,
-    origin_plot_vector_xyam,
-    origin_plot_vector_xyxy,
-    origin_plot_waterfall,
-    origin_recommend_chart,
-)
-from .tools.transform import (
-    origin_concat_worksheets,
-    origin_drop_duplicates,
-    origin_fill_missing,
-    origin_filter_rows,
-    origin_melt_worksheet,
-    origin_merge_worksheets,
-    origin_pivot_worksheet,
-    origin_transpose_worksheet,
-)
-from .tools.worksheet import (
-    origin_add_calculated_column,
-    origin_add_calculated_columns,
-    origin_append_table,
-    origin_clear_worksheet,
-    origin_delete_columns,
-    origin_diagnose_worksheet,
-    origin_export_worksheet_csv,
-    origin_get_cell_value,
-    origin_get_default_plot_config,
-    origin_get_worksheet_info,
-    origin_import_csv,
-    origin_import_excel,
-    origin_import_file,
-    origin_import_table,
-    origin_new_project,
-    origin_open_project,
-    origin_read_worksheet,
-    origin_save_project,
-    origin_set_cell_value,
-    origin_sort_worksheet,
-    origin_write_worksheet,
-)
+
+
+def _register_tools() -> None:
+    """Import every ``origin_mcp.tools`` submodule to register its tools.
+
+    Tool registration is purely an import side effect: importing a module runs
+    its ``@_mcp_tool`` decorators, which register each tool with FastMCP subject
+    to the active tool profile (see ``_shared._should_register_tool``). Importing
+    the package's submodules here therefore replaces the long hand-maintained
+    re-export block this module used to carry — adding a tool no longer requires
+    editing ``server.py``.
+
+    Each module's ``origin_*`` callables are also re-bound onto this module so
+    they stay importable as ``origin_mcp.server.<tool>`` for code and tests that
+    reference them directly. Every ``@_mcp_tool`` function is named ``origin_*``
+    (enforced by ``tests/test_tool_registration.py``), so this binds the full
+    tool surface.
+    """
+
+    for module_info in pkgutil.iter_modules(tools.__path__):
+        name = module_info.name
+        if name.startswith("_"):  # _shared holds no tools; skip private helpers.
+            continue
+        module = importlib.import_module(f"{tools.__name__}.{name}")
+        for attr, value in vars(module).items():
+            if attr.startswith("origin_") and callable(value):
+                globals()[attr] = value
+
+
+_register_tools()
 
 
 def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,37 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pandas as pd
 import pytest
 from fake_origin import FakeOp
 
+from origin_mcp import bridge_client
 from origin_mcp.origin_client import OriginClient
+from origin_mcp.tools import _shared
+
+
+@pytest.fixture(autouse=True)
+def _reset_bridge_client_caches() -> Iterator[None]:
+    """Isolate the process-wide bridge connection caches between tests.
+
+    Bridge sockets are pooled by config (``bridge_client._shared_clients``) and
+    fronted by the ``_shared.client`` proxy facade, both of which live for the
+    whole process. Tests spin up many short-lived bridges that often reuse the
+    same localhost port, so a socket pooled for one test would otherwise leak
+    into the next and connect to a defunct server. Clearing both caches around
+    each test keeps connections deterministic.
+    """
+
+    def _reset() -> None:
+        bridge_client.close_shared_bridge_clients()
+        _shared.client._proxy = None
+        _shared.client._config = None
+
+    _reset()
+    yield
+    _reset()
 
 
 @pytest.fixture


### PR DESCRIPTION
Completes the remaining three items from the earlier code review (the version-single-sourcing and test-coverage items shipped in #5).

## 1. Unify bridge connection caching (`51e7364`)
`OriginBridgeProxy` kept its own private `OriginBridgeClient` instead of the process-wide `_shared_clients` pool, so a bridge shutdown closed the pooled sockets but left the proxy facade holding a stale connection. The proxy now resolves its socket from the shared pool on each call — one source of truth, and a shutdown cleanly forces a reconnect. Adds an autouse test fixture that resets both caches per test (short-lived test bridges reuse localhost ports).

## 2. Auto-register MCP tools (`1f3a480`)
Replaces the ~200-line hand-maintained re-export block in `server.py` with a loop that imports every `origin_mcp.tools` submodule (running the `@_mcp_tool` decorators) and re-binds each module's `origin_*` callables onto `server`. Adding a tool no longer means editing `server.py`; `test_tool_registration.py` still guards the surface. Net −195 lines.

## 3. Tighten mypy on `client.*` (`9afb256`)
The override disabled six error codes wholesale. Fixed the nine real issues it masked and narrowed the suppression to the two codes that are genuine originpro-mixin noise (`attr-defined`, `misc`). `return-value`, `arg-type`, `assignment`, and `union-attr` are now enforced on the client package. Notably corrects the `plot_csv` / `plot_table_by_id` return-type annotations to match their actual tuples.

## Verification
`ruff check` ✅ · `ruff format --check` ✅ · `mypy` ✅ (56 files) · `pytest` ✅ 494 passed, coverage 81.40%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
