### PR TITLE
Attach external originpro to the running Origin instead of spawning one

### DIFF
--- a/src/origin_mcp/client/base.py
+++ b/src/origin_mcp/client/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import threading
 from pathlib import Path
 from typing import Any
@@ -88,7 +89,37 @@ class _OriginClientBase:
                     "run `python -m pip install -e .[origin]`, or make Origin's Python package "
                     "visible to this interpreter."
                 ) from exc
+            self._attach_external_origin_if_needed()
         return self._op
+
+    def _attach_external_origin_if_needed(self) -> None:
+        """Bind external-mode originpro to the running Origin, not a new one.
+
+        When originpro can't find the embedded host API (e.g. Origin 2026 exposes
+        it only as ``_PyOrigin`` and originpro looks for ``PyOrigin``) it runs in
+        external OriginExt mode, where the first call does ``OriginExt.Application()``
+        and launches a BRAND-NEW Origin — so work lands in a spawned window, not
+        the Origin the bridge runs inside, and orphan instances pile up. Calling
+        the wrapper's ``Attach()`` first switches it to ``OriginExt.ApplicationSI()``
+        (single-instance), which connects to the already-running Origin instead.
+
+        No-op in embedded mode (``config.oext`` is False) or when the wrapper has
+        no ``Attach`` (older originpro), and never fatal: on failure we leave
+        originpro to its default behavior. Opt out with
+        ``ORIGIN_MCP_NO_ATTACH=1``.
+        """
+
+        if os.environ.get("ORIGIN_MCP_NO_ATTACH", "").strip().lower() in {"1", "true", "yes", "on"}:
+            return
+        config = getattr(self._op, "config", None)
+        if config is None or not getattr(config, "oext", False):
+            return
+        attach = getattr(getattr(config, "po", None), "Attach", None)
+        if callable(attach):
+            try:
+                attach()
+            except Exception:
+                pass
 
     @staticmethod
     def _normalize_style_mode(style_mode: str | None) -> str:

--- a/tests/test_external_attach.py
+++ b/tests/test_external_attach.py
@@ -1,0 +1,79 @@
+"""Tests for external-mode attach-to-running-Origin behavior.
+
+When originpro runs external (OriginExt) the bridge should attach to the running
+Origin via the wrapper's ``Attach()`` instead of letting the first call spawn a
+new instance. See ``_OriginClientBase._attach_external_origin_if_needed``.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from origin_mcp.origin_client import OriginClient
+
+
+class _PoWrapper:
+    def __init__(self) -> None:
+        self.attached = 0
+
+    def Attach(self) -> None:  # noqa: N802 - mirrors originpro APP.Attach
+        self.attached += 1
+
+
+def _fake_originpro(oext: bool, po: Any) -> types.ModuleType:
+    mod = types.ModuleType("originpro")
+    cfg = types.ModuleType("originpro.config")
+    cfg.oext = oext
+    cfg.po = po
+    mod.config = cfg
+    return mod
+
+
+def test_attaches_when_external(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORIGIN_MCP_NO_ATTACH", raising=False)
+    po = _PoWrapper()
+    client = OriginClient()
+    client._op = _fake_originpro(oext=True, po=po)
+
+    client._attach_external_origin_if_needed()
+
+    assert po.attached == 1
+
+
+def test_noop_when_embedded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORIGIN_MCP_NO_ATTACH", raising=False)
+    po = _PoWrapper()
+    client = OriginClient()
+    client._op = _fake_originpro(oext=False, po=po)
+
+    client._attach_external_origin_if_needed()
+
+    assert po.attached == 0
+
+
+def test_opt_out_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORIGIN_MCP_NO_ATTACH", "1")
+    po = _PoWrapper()
+    client = OriginClient()
+    client._op = _fake_originpro(oext=True, po=po)
+
+    client._attach_external_origin_if_needed()
+
+    assert po.attached == 0
+
+
+def test_attach_failure_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ORIGIN_MCP_NO_ATTACH", raising=False)
+
+    class _Boom:
+        def Attach(self) -> None:  # noqa: N802
+            raise RuntimeError("COM not ready")
+
+    client = OriginClient()
+    client._op = _fake_originpro(oext=True, po=_Boom())
+
+    # Must not raise.
+    client._attach_external_origin_if_needed()


### PR DESCRIPTION
## Problem

When `originpro` can't load Origin's embedded host API it runs in **external (OriginExt) mode**, where the first call does `OriginExt.Application()` and **launches a brand-new Origin**. The bridge then drives that spawned window while the Origin you started the bridge in stays empty, and every bridge session leaks an orphan instance (toward the license limit).

This hits **Origin 2026**: its embedded interpreter exposes the host C-extension only as `_PyOrigin` (no `PyOrigin` wrapper, no bundled originpro), so the pip `originpro` (1.1.15 — the latest on PyPI) can't detect embedded mode and falls back to external.

## Fix

After importing originpro, if `config.oext` is `True`, call `config.po.Attach()` (→ `OriginExt.ApplicationSI()`) so external originpro **connects to the already-running Origin** instead of spawning a new one.

- **Live-verified on Origin 2026** (real bridge): a plot now lands in the Origin you clicked Start in — **no new `Origin64` process**, and `list_project` shows the launch window's own `Book1` alongside the created book. All object ops work (external originpro's object API is fully compatible with 1.1.15).
- Dead ends ruled out first: a raw `sys.modules['PyOrigin']=_PyOrigin` alias *does* flip originpro embedded but Origin 2026's `_PyOrigin.GetPages()` returns a non-iterable SwigPyObject → `import`/`plot`/`list_project` break; and PyPI's latest originpro (1.1.15) is already installed and incompatible.
- No-op in genuine embedded mode (`config.oext` False) and when the wrapper lacks `Attach`; never fatal. Opt out with `ORIGIN_MCP_NO_ATTACH=1`.

## Verification

`ruff` ✅ · `ruff format --check` ✅ · `mypy` ✅ (56 files) · `pytest` ✅ 498 passed, coverage 81.39% (4 new unit tests for the attach logic).

**Note:** the bundled Origin App OPX must be rebuilt to ship this; for the live test the App's `src` copy was synced from the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
