### PR TITLE
Close the spawned external Origin on bridge shutdown

### DIFF
--- a/docs/origin-bridge.md
+++ b/docs/origin-bridge.md
@@ -86,6 +86,22 @@ and Origin can be closed normally. `Ctrl+C` is only a fallback because some
 Origin embedded Python builds do not interrupt the cooperative serve loop
 reliably.
 
+### Embedded vs external Origin
+
+`originpro` runs in *embedded* mode when it can import Origin's host API and
+drives the Origin the bridge runs inside. When that API is unavailable (for
+example Origin 2026 exposes it only as `_PyOrigin`, which the PyPI `originpro`
+does not load), `originpro` falls back to *external* automation and **launches a
+separate Origin process** for the actual data and plots. In that case the window
+you started the bridge in only hosts the socket, and your worksheets/graphs
+appear in the spawned Origin window instead.
+
+To avoid leaking that spawned instance as an orphan (which can hit the Origin
+license limit over repeated sessions), the bridge **closes the external Origin on
+shutdown** even when `close_origin` is not requested. Embedded mode never
+auto-closes the host Origin. Set `ORIGIN_MCP_KEEP_EXTERNAL=1` before launching
+the bridge to keep the external instance running on shutdown instead.
+
 No source directory needs to be edited in `addon.py`. If the file was copied
 away from the checkout and `origin-mcp` is not installed in Origin's Python, set
 `ORIGIN_MCP_SRC` to the checkout `src` directory before running the addon.

--- a/src/origin_mcp/_bridge_server.py
+++ b/src/origin_mcp/_bridge_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hmac
 import json
+import os
 import socketserver
 import threading
 import time
@@ -16,6 +17,18 @@ from .errors import OriginOperationError
 from .logging_config import debug_logging_enabled, log_bridge_event
 from .origin_client import OriginClient
 from .runtime import python_runtime_profile
+
+
+def _keep_external_origin() -> bool:
+    """Opt out of closing the spawned external Origin on bridge shutdown."""
+
+    return os.environ.get("ORIGIN_MCP_KEEP_EXTERNAL", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 47631
@@ -231,16 +244,38 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             error_code="unsupported_bridge_method",
         )
 
+    def _bridge_is_external_origin(self) -> bool:
+        """True when originpro is driving a separately-spawned OriginExt instance.
+
+        Reads the already-imported originpro's ``config.oext`` via the client's
+        cached ``_op`` (never triggers an import). When the embedded host API is
+        unavailable (e.g. Origin 2026 exposes only ``_PyOrigin``), originpro runs
+        external and the bridge's data lives in a spawned Origin process distinct
+        from the one hosting this socket.
+        """
+
+        op = getattr(self.server.client, "_op", None)
+        config = getattr(op, "config", None) if op is not None else None
+        return bool(getattr(config, "oext", False))
+
     def _shutdown_bridge(self, params: dict[str, Any]) -> dict[str, Any]:
         release_origin = bool(params.get("release_origin", True))
         close_origin = bool(params.get("close_origin", False))
+        external = self._bridge_is_external_origin()
         result: dict[str, Any] = {
             "shutdown_requested": True,
             "release_origin": release_origin,
             "close_origin": close_origin,
+            "external_origin": external,
         }
         if release_origin:
-            release_method = "force_quit" if close_origin else "detach"
+            # In external mode the bridge drives a SEPARATE spawned Origin holding
+            # the data; a plain detach leaves it running as an orphan (toward the
+            # license cap), so close it on shutdown. In embedded mode originpro is
+            # the user's host Origin, so only close it when explicitly asked.
+            # Opt out of the external auto-close with ORIGIN_MCP_KEEP_EXTERNAL=1.
+            close_spawned = close_origin or (external and not _keep_external_origin())
+            release_method = "force_quit" if close_spawned else "detach"
             release = getattr(self.server.client, release_method, None)
             if callable(release):
                 try:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -530,9 +530,71 @@ def test_bridge_shutdown_can_keep_origin_alive() -> None:
     finally:
         server.server_close()
 
-    assert result == {"shutdown_requested": True, "release_origin": False, "close_origin": False}
-    assert fake_client.force_closed is False
+    assert result == {
+        "shutdown_requested": True,
+        "release_origin": False,
+        "close_origin": False,
+        "external_origin": False,
+    }
+
+
+def test_bridge_shutdown_closes_spawned_external_origin() -> None:
+    import types
+
+    # Simulate external (OriginExt) mode: originpro is imported with config.oext
+    # True, so the bridge drives a separately-spawned Origin. Shutdown should
+    # close that spawned instance even though close_origin was not requested, so
+    # it is not left as an orphan.
+    fake_client = FakeOriginClient()
+    op_mod = types.ModuleType("originpro")
+    cfg = types.ModuleType("originpro.config")
+    cfg.oext = True
+    op_mod.config = cfg
+    fake_client._op = op_mod  # type: ignore[attr-defined]
+
+    server = OriginBridgeServer(("127.0.0.1", 0), client=fake_client)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = bridge_client(server).request("shutdown")
+        thread.join(timeout=2)
+    finally:
+        server.server_close()
+
+    assert result["external_origin"] is True
+    assert result["close_origin"] is False
+    assert result["origin_release_method"] == "force_quit"
+    assert fake_client.force_closed is True
     assert fake_client.detached is False
+
+
+def test_bridge_shutdown_keeps_external_origin_when_opted_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import types
+
+    monkeypatch.setenv("ORIGIN_MCP_KEEP_EXTERNAL", "1")
+    fake_client = FakeOriginClient()
+    op_mod = types.ModuleType("originpro")
+    cfg = types.ModuleType("originpro.config")
+    cfg.oext = True
+    op_mod.config = cfg
+    fake_client._op = op_mod  # type: ignore[attr-defined]
+
+    server = OriginBridgeServer(("127.0.0.1", 0), client=fake_client)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = bridge_client(server).request("shutdown")
+        thread.join(timeout=2)
+    finally:
+        server.server_close()
+
+    # Opt-out: external instance is left running (detach), not force-closed.
+    assert result["external_origin"] is True
+    assert result["origin_release_method"] == "detach"
+    assert fake_client.detached is True
+    assert fake_client.force_closed is False
     assert not thread.is_alive()
 
 


### PR DESCRIPTION
## Problem

When `originpro` can't load Origin's embedded host API it runs in **external (OriginExt) mode** and launches a **separate Origin process** to hold the data — the case on **Origin 2026**, which exposes the host API only as `_PyOrigin` (the PyPI `originpro` looks for `PyOrigin` and falls back to external). A plain `detach` on shutdown left that spawned instance running, so Origin instances **accumulated as orphans** across sessions, toward the license limit.

## Fix

On `origin_bridge_shutdown`, detect external mode via the client's already-imported `originpro.config.oext` and **close the spawned instance** (`force_quit` → `Exit(False)`) even when `close_origin` wasn't requested.

- **Embedded mode is unchanged**: there `originpro` *is* the user's host Origin, so it's only closed on an explicit `close_origin` — never auto-closed.
- Opt out with `ORIGIN_MCP_KEEP_EXTERNAL=1`.
- The shutdown result now reports `external_origin`.
- Reads `oext` off the cached `_op` (never triggers an import); no new COM connections — reuses the existing `force_quit` path.

## Why this and not "attach to the running Origin"

The alternative (make the bridge attach to the Origin it runs inside via `OriginExt.ApplicationSI()`) was tried in #7 and **crashed Origin** in live testing (in-process COM self-attach). This change is the safe option: it doesn't change which window the data lands in — it only prevents orphan accumulation.

## Verification

`ruff` ✅ · `ruff format --check` ✅ · `mypy` ✅ (56 files) · `pytest` ✅ 496 passed, coverage 81.42%. Added two unit tests (external auto-close, and the `ORIGIN_MCP_KEEP_EXTERNAL` opt-out). Docs updated in `docs/origin-bridge.md` (embedded vs external + auto-close).

**Not live-tested** against a real bridge by request — it uses the pre-existing `force_quit` path, so the risk is limited to *when* that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
