### PR TITLE
Disable mypy site-packages and add overrides for numpy/pandas/openpyxl/xlrd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,23 @@ mypy_path = "src"
 ignore_missing_imports = true
 namespace_packages = true
 explicit_package_bases = true
+no_site_packages = true
+
+[[tool.mypy.overrides]]
+# Keep mypy focused on origin-mcp itself across the full supported Python range.
+# Recent pandas/numpy wheels may ship type stubs that use syntax newer than our
+# Python 3.10 checking target, so site-packages are disabled globally and these
+# imports are explicitly treated as external Any-typed dependencies.
+module = [
+  "numpy",
+  "numpy.*",
+  "openpyxl",
+  "pandas",
+  "pandas.*",
+  "xlrd",
+]
+follow_imports = "skip"
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 # OriginClient is assembled from cooperating mixins (_TablePlotMixin,


### PR DESCRIPTION
### Motivation
- Limit type checking to the project itself and avoid failures caused by third-party stubs that may require newer Python syntax by disabling site-packages and treating common numeric/IO libraries as external.

### Description
- Updated `pyproject.toml` to set `no_site_packages = true` under `[tool.mypy]` and added an `[[tool.mypy.overrides]]` block that lists `numpy`, `numpy.*`, `openpyxl`, `pandas`, `pandas.*`, and `xlrd` with `follow_imports = "skip"` and `ignore_missing_imports = true` so these imports are treated as external Any-typed dependencies.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c162ba48c83268c59d1154a738a3b)