### PR TITLE
Add Dependabot config for weekly pip and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-runtime:
+        patterns:
+          - "mcp"
+          - "pydantic"
+          - "pandas"
+          - "openpyxl"
+          - "xlrd"
+      python-dev:
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "mypy"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
### Motivation
- Add a Dependabot configuration to automate weekly dependency updates for Python packages and GitHub Actions using pattern-based grouping.

### Description
- Add `.github/dependabot.yml` which enables weekly `pip` and `github-actions` updates, limits open pull requests to 5, and configures `python-runtime` and `python-dev` groups with patterns such as `mcp`, `pydantic`, `pandas`, `openpyxl`, `xlrd`, `pytest*`, `ruff`, and `mypy`.

### Testing
- No automated tests were run for this repository configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a509a2634b48326b44b01f545340812)