### PR TITLE
Document Windows Origin launch troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ bridge down (it calls `origin_bridge_shutdown`), or double-click
 open either way.
 
 If a package is missing or the bridge will not start, see
-[docs/origin-bridge.md](docs/origin-bridge.md).
+[docs/origin-bridge.md](docs/origin-bridge.md). That guide also covers common
+Windows path and LabTalk launch pitfalls when starting `addon.py` manually.
 
 ## Security
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -132,6 +132,7 @@ import runpy; runpy.run_path(r"C:\path\to\origin-mcp\addon.py", run_name="__main
 关闭 Origin。
 
 若缺少依赖包或 bridge 起不来，请参阅 [docs/origin-bridge.md](docs/origin-bridge.md)。
+该文档也说明了手动启动 `addon.py` 时常见的 Windows 路径转义和 LabTalk 命令解析问题。
 
 ## 安全性
 

--- a/docs/origin-bridge.md
+++ b/docs/origin-bridge.md
@@ -25,6 +25,34 @@ import runpy; runpy.run_path(r"C:\path\to\origin-mcp\addon.py", run_name="__main
 
 Replace `C:\path\to\origin-mcp` with the local checkout path.
 
+### Windows path and LabTalk launch pitfalls
+
+Prefer the Python Console snippet above for manual startup. It runs in pure
+Python mode and uses a raw string for the Windows path, so `C:\Users\...` is
+not parsed as a Python `\UXXXXXXXX` Unicode escape.
+
+If you launch from Origin's LabTalk Command Window instead, keep the command
+simple and use forward slashes for Windows paths that are passed into Python:
+
+```labtalk
+run -pyf "C:/path/to/origin-mcp/addon.py";
+```
+
+Avoid complex inline commands such as nested `Python -exec "exec(open(...))"`
+strings at the LabTalk `>>` prompt. Origin's LabTalk parser can treat the text
+as a worksheet formula before Python sees it, which may produce misleading
+messages such as `Math cannot be performed on Text column`. When you need to
+force Origin to read the current on-disk file during development, switch the
+Command Window to Python mode first by entering `Python`, then run:
+
+```python
+exec(open(r"C:\path\to\origin-mcp\addon.py", encoding="utf-8").read())
+```
+
+Use this reload form only for development or troubleshooting. For normal use,
+the Python Console launch snippet or the Origin MCP Bridge Start App is clearer
+and less fragile.
+
 `addon.py` does not hard-code the checkout directory. It first tries to import
 an installed `origin_mcp` package from Origin's embedded Python. If that is not
 available, it looks for a sibling `src\origin_mcp` directory next to `addon.py`.
@@ -195,6 +223,9 @@ workflow:
 ```json
 {"ping_origin": true}
 ```
+
+On Windows, `WinError 10061` usually means nothing is listening at the bridge
+host and port yet: start `addon.py` inside Origin, then retry `origin_doctor`.
 
 Search the knowledge base for `bridge diagnostics` when you need the canonical
 troubleshooting checklist.

--- a/docs/origin-ui-buttons.md
+++ b/docs/origin-ui-buttons.md
@@ -62,7 +62,7 @@ Replace `C:\path\to\origin-mcp` with your checkout path.
 
 ```labtalk
 [OriginMCPStart]
-string addon_path$ = "C:\path\to\origin-mcp\addon.py";
+string addon_path$ = "C:/path/to/origin-mcp/addon.py";
 run -pyf "%(addon_path$)";
 
 [OriginMCPStop]
@@ -92,7 +92,7 @@ User Files Folder:
 
 ```labtalk
 [Start]
-string addon_path$ = "C:\path\to\origin-mcp\addon.py";
+string addon_path$ = "C:/path/to/origin-mcp/addon.py";
 run -pyf "%(addon_path$)";
 
 [Stop]


### PR DESCRIPTION
## Summary

- Document Windows path and LabTalk launch pitfalls for manual Origin bridge startup
- Point users from the English and Chinese READMEs to the bridge troubleshooting guide
- Update LabTalk button examples to use forward slashes for Python script paths

## Why

Issue #13 reports several Windows/Origin setup traps: `WinError 10061`, Python `unicodeescape` errors with paths like `C:\Users\...`, LabTalk misparsing complex inline `Python -exec "exec(open(...))"` commands, and development-time reload confusion. These are startup and troubleshooting guidance issues rather than core bridge logic bugs.

## Validation

- `python -m pytest tests\test_docs_dedup.py tests\test_origin_app_packaging.py`