### PR TITLE
Add CLI bridge diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ If a package is missing or the bridge will not start, see
 [docs/origin-bridge.md](docs/origin-bridge.md). That guide also covers common
 Windows path and LabTalk launch pitfalls when starting `addon.py` manually.
 
+## Check Bridge Status
+
+Check the bridge without driving Origin:
+
+```powershell
+origin-mcp status
+```
+
+For a fuller report, optionally including a live Origin connection check:
+
+```powershell
+origin-mcp doctor --ping-origin
+```
+
+Both commands accept `--json` for scripts and agents. Their exit codes are `0`
+for healthy, `1` for not running, `2` for starting/degraded/failed, and `3` when
+the diagnostic command itself cannot complete. `python -m origin_mcp status`
+and `python -m origin_mcp doctor` are equivalent; running either entry point
+without arguments still starts the MCP server over stdio.
+
 ## Security
 
 The bridge listens only on `127.0.0.1` and authenticates local requests by

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,7 @@
 # origin-mcp
 
+![origin-mcp cover](docs/assets/github-readme-cover.png)
+
 [![PyPI version](https://img.shields.io/pypi/v/origin-mcp)](https://pypi.org/project/origin-mcp/)
 [![Downloads](https://static.pepy.tech/badge/origin-mcp)](https://pepy.tech/projects/origin-mcp)
 [![Python versions](https://img.shields.io/pypi/pyversions/origin-mcp)](https://pypi.org/project/origin-mcp/)
@@ -122,9 +124,17 @@ MCP 客户端配置示例：
 bridge 跑在 Origin 自带的 Python 里，这样 `originpro` 始终在 Origin 的 UI 线程上
 执行。无需任何额外配置，每个 Origin 会话启动一次即可：
 
-**Origin App（推荐日常使用）。** 按 [docs/origin-ui-buttons.md](docs/origin-ui-buttons.md)
-一次性生成并安装两个 bridge App。之后在 Apps 库里点 **Origin MCP Bridge Start** 启动
-bridge，点 **Origin MCP Bridge Stop** 关闭。
+**Origin App（推荐日常使用）。** 安装 Python 包后，先生成两个自包含的 bridge App：
+
+```powershell
+origin-mcp install-origin-app --force
+```
+
+然后按 [docs/origin-ui-buttons.md](docs/origin-ui-buttons.md) 中的简短注册步骤，在 Origin
+里打包并安装命令生成的两个 OPX 文件。之后在 Apps 库里点
+**Origin MCP Bridge Start** 启动 bridge，点 **Origin MCP Bridge Stop** 关闭。Start App
+使用可靠的前台协作模式；Stop App 通过独立的隐藏辅助进程发送停止请求，因此需要保留为
+两个 App 入口，而不是单一切换按钮。
 
 **Python Console（临时使用或排查问题）。** 打开 Origin 的 **Python Console**，粘贴这一行
 （把路径换成你的项目路径）：
@@ -140,6 +150,25 @@ import runpy; runpy.run_path(r"C:\path\to\origin-mcp\addon.py", run_name="__main
 
 若缺少依赖包或 bridge 起不来，请参阅 [docs/origin-bridge.md](docs/origin-bridge.md)。
 该文档也说明了手动启动 `addon.py` 时常见的 Windows 路径转义和 LabTalk 命令解析问题。
+
+## 检查 bridge 状态
+
+只检查 bridge 是否运行，不驱动 Origin：
+
+```powershell
+origin-mcp status
+```
+
+需要完整诊断时，可额外检查与 Origin 的实时连接：
+
+```powershell
+origin-mcp doctor --ping-origin
+```
+
+两个命令都支持 `--json`，便于脚本和 Agent 读取。退出码固定为：`0` 表示健康，`1`
+表示未运行，`2` 表示正在启动、功能降级或启动失败，`3` 表示诊断命令自身无法完成。
+`python -m origin_mcp status` 和 `python -m origin_mcp doctor` 具有相同行为；两个入口在
+不带参数时仍会通过 stdio 启动 MCP server。
 
 ## 安全性
 

--- a/docs/agentic/origin-mcp-bootstrap.md
+++ b/docs/agentic/origin-mcp-bootstrap.md
@@ -151,11 +151,15 @@ Get-CimInstance Win32_Process |
 
 [USER ACTION REQUIRED]
 
-For daily use, build and install the Origin OPX from `docs/origin-ui-buttons.md`,
-then click the **Origin MCP Bridge** App icon inside Origin as a single bridge
-toggle.
-If the OPX background bridge does not process requests on that installation,
-fall back to the manual foreground startup below.
+For daily use, build and install both Origin OPX Apps from
+`docs/origin-ui-buttons.md`. Click **Origin MCP Bridge Start** to run the bridge
+in reliable foreground cooperative mode, and click **Origin MCP Bridge Stop**
+to request shutdown through its separate hidden helper process. These are two
+App entries rather than a single toggle because the foreground bridge keeps
+Origin's embedded Python script engine busy; an in-process re-entrant stop click
+is not reliable across Origin installations.
+If the Start App does not process requests on that installation, fall back to
+the manual foreground startup below.
 
 For manual startup or troubleshooting, in Origin/OriginPro:
 

--- a/docs/origin-bridge.md
+++ b/docs/origin-bridge.md
@@ -236,6 +236,19 @@ host and port yet: start `addon.py` inside Origin, then retry `origin_doctor`.
 Search the knowledge base for `bridge diagnostics` when you need the canonical
 troubleshooting checklist.
 
+Before an MCP client is connected, the equivalent command-line checks are:
+
+```powershell
+origin-mcp status
+origin-mcp doctor --ping-origin
+```
+
+Add `--json` for machine-readable output. The commands return `0` when healthy,
+`1` when the bridge is not running, `2` when startup failed or the live Origin
+check is degraded, and `3` when diagnostics could not be completed. The status
+command only probes the local bridge; `doctor --ping-origin` may bring the
+Origin window forward while checking automation.
+
 ## High-Level Bridge Workflows
 
 The bridge can run file-to-figure workflows without `originpro` calls in the MCP

--- a/docs/origin-ui-buttons.md
+++ b/docs/origin-ui-buttons.md
@@ -65,6 +65,14 @@ an external hidden helper to send a bridge `shutdown` request with
 `release_origin=true`, so it can stop the foreground bridge even when Origin's
 embedded Python is busy serving requests.
 
+The two entries are intentional. An earlier single-button toggle tried to run
+the stop path re-entrantly inside the same Origin Python context. That is not
+reliable while the foreground cooperative serve loop owns the script engine.
+A synchronous external stop helper would block the same thread that must answer
+its shutdown request, while an asynchronous helper cannot reliably return a
+start/stop decision to the original click. Keeping Start in Origin and Stop in a
+separate asynchronous helper avoids both failure modes.
+
 ## Quick Setup With Custom.ogs
 
 Origin's Standard toolbar includes a Custom Routine button that runs LabTalk

--- a/src/origin_mcp/__main__.py
+++ b/src/origin_mcp/__main__.py
@@ -1,4 +1,4 @@
-from .server import main
+from .cli import main
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/origin_mcp/cli.py
+++ b/src/origin_mcp/cli.py
@@ -1,28 +1,52 @@
-"""Command-line entry point for the MCP server and setup helpers."""
+"""Command-line entry point for the MCP server, setup, and diagnostics."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections.abc import Sequence
+from typing import Any, TextIO
+
+from .diagnostics import (
+    EXIT_DIAGNOSTIC_ERROR,
+    classify_diagnostics,
+    collect_diagnostics,
+)
 
 
-def main(argv: Sequence[str] | None = None) -> None:
-    """Run the MCP server by default, or an explicitly requested setup command.
+def _add_diagnostic_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    default_timeout: float,
+) -> None:
+    parser.add_argument("--host", help="override the Origin bridge host")
+    parser.add_argument("--port", type=int, help="override the Origin bridge port")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=default_timeout,
+        help=f"bridge probe timeout in seconds (default: {default_timeout:g})",
+    )
+    parser.add_argument("--status-path", help="override the bridge status-file path")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="emit machine-readable JSON",
+    )
 
-    Keeping the no-argument behavior identical to the historical console script
-    means existing MCP client configurations continue to work unchanged.
-    """
 
-    args = list(sys.argv[1:] if argv is None else argv)
-    if not args:
-        from .server import main as server_main
-
-        server_main()
-        return
-
-    parser = argparse.ArgumentParser(prog="origin-mcp")
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="origin-mcp",
+        description=(
+            "Run the origin-mcp server or inspect the local Origin bridge. "
+            "With no arguments, the MCP server runs over stdio."
+        ),
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
+
     install = subparsers.add_parser(
         "install-origin-app",
         help="install the Origin MCP Bridge Start/Stop Apps for the current user",
@@ -37,7 +61,175 @@ def main(argv: Sequence[str] | None = None) -> None:
         help="override the Origin Apps directory (primarily for testing)",
     )
 
-    parsed = parser.parse_args(args)
+    status = subparsers.add_parser(
+        "status",
+        help="show whether the local Origin bridge is running",
+    )
+    _add_diagnostic_arguments(status, default_timeout=1.0)
+
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="diagnose bridge configuration, status, logs, and connectivity",
+    )
+    _add_diagnostic_arguments(doctor, default_timeout=2.0)
+    doctor.add_argument(
+        "--ping-origin",
+        action="store_true",
+        help="also ask the bridge to connect to Origin (may show the Origin window)",
+    )
+    return parser
+
+
+def _json_payload(report: dict[str, Any], assessment: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "state": assessment["state"],
+        "exit_code": assessment["exit_code"],
+        "status_age_seconds": assessment["status_age_seconds"],
+        "status_stale": assessment["status_stale"],
+        "diagnostics": report,
+    }
+
+
+def _write_json(payload: dict[str, Any], stream: TextIO | None = None) -> None:
+    print(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        file=stream or sys.stdout,
+    )
+
+
+def _state_label(state: str) -> str:
+    return state.replace("_", " ").upper()
+
+
+def _format_age(age_seconds: Any) -> str | None:
+    if not isinstance(age_seconds, (int, float)):
+        return None
+    if age_seconds < 60:
+        return f"{age_seconds:.0f}s ago"
+    if age_seconds < 3600:
+        return f"{age_seconds / 60:.0f}m ago"
+    if age_seconds < 86400:
+        return f"{age_seconds / 3600:.1f}h ago"
+    return f"{age_seconds / 86400:.1f}d ago"
+
+
+def _dict_value(mapping: dict[str, Any], key: str) -> dict[str, Any]:
+    value = mapping.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _write_human_report(
+    report: dict[str, Any],
+    assessment: dict[str, Any],
+    *,
+    detailed: bool,
+    stream: TextIO | None = None,
+) -> None:
+    output = stream or sys.stdout
+    label = "Origin MCP doctor" if detailed else "Origin MCP bridge"
+    print(f"{label}: {_state_label(str(assessment['state']))}", file=output)
+
+    config = _dict_value(report, "config")
+    print(f"Address: {config.get('host')}:{config.get('port')}", file=output)
+
+    bridge = _dict_value(report, "bridge")
+    if bridge.get("ok"):
+        print("Bridge: reachable", file=output)
+    else:
+        error_code = bridge.get("error_code") or "unavailable"
+        print(f"Bridge: unreachable ({error_code})", file=output)
+        if bridge.get("message"):
+            print(f"  {bridge['message']}", file=output)
+
+    status_file = _dict_value(report, "status_file")
+    if status_file.get("exists"):
+        suffix: list[str] = []
+        age = _format_age(assessment.get("status_age_seconds"))
+        if age:
+            suffix.append(age)
+        if assessment.get("status_stale"):
+            suffix.append("stale")
+        detail = f" ({', '.join(suffix)})" if suffix else ""
+        print(f"Status file: {status_file.get('path')}{detail}", file=output)
+    else:
+        print(f"Status file: not found ({status_file.get('path')})", file=output)
+
+    status = _dict_value(report, "status_diagnostics")
+    if status.get("install_phase") and assessment.get("state") not in {"running", "stopped"}:
+        print(f"Install phase: {status['install_phase']}", file=output)
+    if status.get("last_error"):
+        error_type = status.get("last_error_type")
+        prefix = f"{error_type}: " if error_type else ""
+        print(f"Last error: {prefix}{status['last_error']}", file=output)
+
+    if detailed:
+        origin = report.get("origin")
+        if origin is None:
+            print("Origin: not checked (use --ping-origin)", file=output)
+        elif isinstance(origin, dict) and origin.get("ok"):
+            print("Origin: reachable", file=output)
+        elif isinstance(origin, dict):
+            print(f"Origin: failed ({origin.get('error_code') or 'unknown'})", file=output)
+            if origin.get("message"):
+                print(f"  {origin['message']}", file=output)
+
+        log = _dict_value(report, "log")
+        if log.get("enabled"):
+            availability = "exists" if log.get("exists") else "no records yet"
+            print(f"Log: {log.get('path')} ({availability})", file=output)
+        else:
+            print("Log: disabled", file=output)
+
+    recommendations = report.get("recommendations")
+    if isinstance(recommendations, list) and recommendations:
+        print("Next actions:", file=output)
+        limit = None if detailed else 3
+        for item in recommendations[:limit]:
+            print(f"  - {item}", file=output)
+
+
+def _run_diagnostics(parsed: argparse.Namespace, *, detailed: bool) -> int:
+    json_output = bool(parsed.json_output)
+    try:
+        report = collect_diagnostics(
+            host=parsed.host,
+            port=parsed.port,
+            timeout=parsed.timeout,
+            status_path=parsed.status_path,
+            ping_origin=bool(getattr(parsed, "ping_origin", False)),
+        )
+        assessment = classify_diagnostics(report)
+    except Exception as exc:
+        payload = {
+            "state": "diagnostic_error",
+            "exit_code": EXIT_DIAGNOSTIC_ERROR,
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+        if json_output:
+            _write_json(payload)
+        else:
+            print(f"Origin MCP diagnostics failed: {exc}", file=sys.stderr)
+        return EXIT_DIAGNOSTIC_ERROR
+
+    if json_output:
+        _write_json(_json_payload(report, assessment))
+    else:
+        _write_human_report(report, assessment, detailed=detailed)
+    return int(assessment["exit_code"])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the MCP server by default, or an explicitly requested CLI command."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        from .server import main as server_main
+
+        server_main()
+        return 0
+
+    parsed = _build_parser().parse_args(args)
     if parsed.command == "install-origin-app":
         from .app_installer import install_origin_apps
 
@@ -53,3 +245,9 @@ def main(argv: Sequence[str] | None = None) -> None:
             opx = path.with_suffix(".opx")
             print(f'mkOPX app:="{path.name}" opx:="{opx}";')
         print("Then drag both OPX files into Origin to register the Apps.")
+        return 0
+    if parsed.command == "status":
+        return _run_diagnostics(parsed, detailed=False)
+    if parsed.command == "doctor":
+        return _run_diagnostics(parsed, detailed=True)
+    raise RuntimeError(f"Unhandled command: {parsed.command}")

--- a/src/origin_mcp/diagnostics.py
+++ b/src/origin_mcp/diagnostics.py
@@ -1,0 +1,392 @@
+"""Shared Origin bridge diagnostics for MCP tools and the command-line interface."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .bridge_client import OriginBridgeConfig, request_bridge
+from .bridge_handshake import read_handshake
+from .errors import OriginBridgeError
+from .logging_config import active_log_path, tail_log
+
+EXIT_HEALTHY = 0
+EXIT_NOT_RUNNING = 1
+EXIT_DEGRADED = 2
+EXIT_DIAGNOSTIC_ERROR = 3
+DEFAULT_STALE_AFTER_SECONDS = 15 * 60
+
+_STARTING_PHASES = {
+    "initializing",
+    "checking_dependencies",
+    "installing_dependencies",
+    "dependencies_ready",
+    "loading_bridge_server",
+}
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            unique.append(value)
+    return unique
+
+
+def _configured_status_file_candidates(status_path: str | None = None) -> list[Path]:
+    candidates: list[Path] = []
+    handshake = read_handshake() or {}
+    for value in (
+        status_path,
+        os.environ.get("ORIGIN_MCP_BRIDGE_STATUS"),
+        handshake.get("status_path"),
+    ):
+        if value:
+            candidates.append(Path(value).expanduser())
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        key = os.path.normcase(str(resolved))
+        if key not in seen:
+            seen.add(key)
+            unique.append(resolved)
+    return unique
+
+
+def status_file_candidates(status_path: str | None = None) -> list[Path]:
+    """Return configured and conventional status-file candidates."""
+
+    candidates = _configured_status_file_candidates(status_path)
+    candidates.extend(
+        [
+            Path.cwd() / "origin-bridge.status.txt",
+            Path(__file__).resolve().parents[2] / "origin-bridge.status.txt",
+        ]
+    )
+    local_appdata = os.environ.get("LOCALAPPDATA")
+    if local_appdata:
+        candidates.append(
+            Path(local_appdata)
+            / "OriginLab"
+            / "Apps"
+            / "Origin MCP Bridge Start"
+            / "origin-bridge.status.txt"
+        )
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        key = os.path.normcase(str(resolved))
+        if key not in seen:
+            seen.add(key)
+            unique.append(resolved)
+    return unique
+
+
+def read_bridge_status(status_path: str | None = None) -> dict[str, Any]:
+    """Read the first available bridge status file without raising on bad content."""
+
+    candidates = status_file_candidates(status_path)
+    configured = _configured_status_file_candidates(status_path)
+    configured_keys = {os.path.normcase(str(path)) for path in configured}
+    fallback_with_mtime: list[tuple[float, Path]] = []
+    for candidate in candidates:
+        if os.path.normcase(str(candidate)) in configured_keys or not candidate.exists():
+            continue
+        try:
+            modified = candidate.stat().st_mtime
+        except OSError:
+            modified = float("-inf")
+        fallback_with_mtime.append((modified, candidate))
+    ordered = configured + [
+        candidate
+        for _, candidate in sorted(fallback_with_mtime, key=lambda item: item[0], reverse=True)
+    ]
+
+    for candidate in ordered:
+        if not candidate.exists():
+            continue
+        try:
+            text = candidate.read_text(encoding="utf-8")
+        except OSError as exc:
+            return {
+                "path": str(candidate),
+                "exists": True,
+                "readable": False,
+                "error": str(exc),
+                "candidates": [str(path) for path in candidates],
+            }
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            data = None
+        return {
+            "path": str(candidate),
+            "exists": True,
+            "readable": True,
+            "format": "json" if isinstance(data, dict) else "text",
+            "data": data if isinstance(data, dict) else None,
+            "raw_preview": None if isinstance(data, dict) else text[:1000],
+            "candidates": [str(path) for path in candidates],
+        }
+    return {
+        "path": str(candidates[0]) if candidates else None,
+        "exists": False,
+        "readable": False,
+        "candidates": [str(path) for path in candidates],
+    }
+
+
+def _status_runtime_recommendations(status_data: dict[str, Any]) -> list[str]:
+    probe = status_data.get("runtime_probe")
+    if not isinstance(probe, dict):
+        return []
+
+    recommendations: list[str] = []
+    if probe.get("inside_origin", probe.get("likely_origin_embedded_python")) is False:
+        recommendations.append(
+            "The status file does not look like it came from Origin's embedded Python. "
+            "Start addon.py from Origin's Python Console or the Origin MCP Bridge Start App, "
+            "not from a normal terminal Python."
+        )
+    inside_origin = probe.get("inside_origin", probe.get("likely_origin_embedded_python")) is True
+    embedded_api = (
+        probe.get(
+            "embedded_api_available",
+            probe.get("origin_host_api_available"),
+        )
+        is True
+    )
+    if probe.get("originpro_available") is False and not (inside_origin and embedded_api):
+        recommendations.append(
+            "originpro was not importable when addon.py wrote the status file. Start the "
+            "bridge inside Origin, or allow addon.py to install missing runtime dependencies."
+        )
+    return recommendations
+
+
+def status_diagnostics(status_data: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the stable, user-relevant subset of a raw status payload."""
+
+    if not isinstance(status_data, dict):
+        return {}
+    probe = status_data.get("runtime_probe")
+    probe_data = probe if isinstance(probe, dict) else {}
+    return {
+        "message": status_data.get("message"),
+        "running": status_data.get("running"),
+        "install_phase": status_data.get("install_phase"),
+        "last_successful_start": status_data.get("last_successful_start"),
+        "last_error": status_data.get("last_error"),
+        "last_error_type": status_data.get("last_error_type"),
+        "inside_origin": probe_data.get(
+            "inside_origin",
+            probe_data.get("likely_origin_embedded_python"),
+        ),
+        "embedded_api_available": probe_data.get(
+            "embedded_api_available",
+            probe_data.get("origin_host_api_available"),
+        ),
+        "originpro_available": probe_data.get("originpro_available"),
+        "originpro_source": probe_data.get("originpro_source"),
+        "python_executable": status_data.get("python_executable"),
+        "python_version": status_data.get("python_version"),
+        "status_updated_at": status_data.get("updated_at"),
+    }
+
+
+def collect_diagnostics(
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    token: str | None = None,
+    timeout: float | None = 2.0,
+    status_path: str | None = None,
+    ping_origin: bool = False,
+    config_metadata: dict[str, Any] | None = None,
+    request_fn: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Collect bridge, optional Origin, status-file, log, and recovery diagnostics."""
+
+    config = OriginBridgeConfig.from_env(host=host, port=port, token=token, timeout=timeout)
+    status_file = read_bridge_status(status_path)
+    bridge_check: dict[str, Any] = {"ok": False}
+    origin_check: dict[str, Any] | None = None
+    recommendations: list[str] = []
+    bridge_request = request_fn or request_bridge
+
+    try:
+        response = bridge_request(
+            "ping",
+            host=config.host,
+            port=config.port,
+            token=config.token,
+            timeout=config.timeout,
+        )
+        bridge_check = {"ok": True, "response": response}
+    except OriginBridgeError as exc:
+        bridge_check = {
+            "ok": False,
+            "error_code": exc.error_code,
+            "message": str(exc),
+        }
+        recommendations.append(
+            "Start Origin and click the Origin MCP Bridge Start App. For manual startup, "
+            "open Origin's Python Console and run the root addon.py."
+        )
+        recommendations.append(
+            "If addon.py is already running, compare ORIGIN_MCP_BRIDGE_HOST and "
+            "ORIGIN_MCP_BRIDGE_PORT with the status file."
+        )
+
+    if ping_origin and bridge_check["ok"]:
+        try:
+            origin_check = {
+                "ok": True,
+                "response": bridge_request(
+                    "origin_ping",
+                    {"show": True},
+                    host=config.host,
+                    port=config.port,
+                    token=config.token,
+                    timeout=max(float(config.timeout), 10.0),
+                ),
+            }
+        except OriginBridgeError as exc:
+            origin_check = {
+                "ok": False,
+                "error_code": exc.error_code,
+                "message": str(exc),
+            }
+            recommendations.append(
+                "The bridge responded, but Origin automation failed. Check the live Origin "
+                "session and the status file last_error field."
+            )
+
+    status_data = status_file.get("data")
+    if isinstance(status_data, dict) and status_data.get("last_error"):
+        recommendations.append(
+            "addon.py recorded last_error in the status file; inspect that field first."
+        )
+    if isinstance(status_data, dict):
+        recommendations.extend(_status_runtime_recommendations(status_data))
+    if not status_file.get("exists"):
+        recommendations.append(
+            "No bridge status file was found. Set ORIGIN_MCP_BRIDGE_STATUS or start addon.py "
+            "from the checkout root."
+        )
+
+    log_path = active_log_path()
+    log_info: dict[str, Any] = {
+        "path": str(log_path) if log_path else None,
+        "enabled": log_path is not None,
+        "exists": bool(log_path and log_path.exists()),
+        "recent": tail_log(20) if log_path and log_path.exists() else [],
+    }
+    config_info: dict[str, Any] = {
+        "host": config.host,
+        "port": config.port,
+        "timeout": config.timeout,
+        "token_configured": bool(config.token),
+        "env": {
+            "ORIGIN_MCP_BRIDGE_HOST": os.environ.get("ORIGIN_MCP_BRIDGE_HOST"),
+            "ORIGIN_MCP_BRIDGE_PORT": os.environ.get("ORIGIN_MCP_BRIDGE_PORT"),
+            "ORIGIN_MCP_BRIDGE_TIMEOUT": os.environ.get("ORIGIN_MCP_BRIDGE_TIMEOUT"),
+            "ORIGIN_MCP_BRIDGE_STATUS": os.environ.get("ORIGIN_MCP_BRIDGE_STATUS"),
+            "ORIGIN_MCP_BRIDGE_TOKEN": bool(os.environ.get("ORIGIN_MCP_BRIDGE_TOKEN")),
+            "ORIGIN_MCP_TOOL_PROFILE": os.environ.get("ORIGIN_MCP_TOOL_PROFILE"),
+            "ORIGIN_MCP_LOG_FILE": os.environ.get("ORIGIN_MCP_LOG_FILE"),
+        },
+    }
+    if config_metadata:
+        config_info.update(config_metadata)
+
+    return {
+        "config": config_info,
+        "status_file": status_file,
+        "status_diagnostics": status_diagnostics(
+            status_data if isinstance(status_data, dict) else None
+        ),
+        "bridge": bridge_check,
+        "origin": origin_check,
+        "log": log_info,
+        "recommendations": _dedupe_strings(recommendations),
+    }
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def classify_diagnostics(
+    report: dict[str, Any],
+    *,
+    stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Classify a diagnostic report into a CLI state and stable exit code."""
+
+    bridge = report.get("bridge")
+    if not isinstance(bridge, dict) or "ok" not in bridge:
+        return {
+            "state": "diagnostic_error",
+            "exit_code": EXIT_DIAGNOSTIC_ERROR,
+            "status_age_seconds": None,
+            "status_stale": False,
+        }
+
+    status_file = report.get("status_file")
+    status_file_data = status_file if isinstance(status_file, dict) else {}
+    raw_status = status_file_data.get("data")
+    status_data = raw_status if isinstance(raw_status, dict) else {}
+    updated_at = _parse_timestamp(status_data.get("updated_at"))
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    age_seconds = (
+        max(0.0, (current.astimezone(timezone.utc) - updated_at).total_seconds())
+        if updated_at
+        else None
+    )
+    stale = bool(age_seconds is not None and age_seconds > stale_after_seconds)
+
+    if bridge.get("ok"):
+        origin = report.get("origin")
+        if isinstance(origin, dict) and not origin.get("ok"):
+            state, exit_code = "degraded", EXIT_DEGRADED
+        else:
+            state, exit_code = "running", EXIT_HEALTHY
+    elif status_data.get("last_error") or status_data.get("install_phase") == "failed":
+        state, exit_code = "failed", EXIT_DEGRADED
+    elif stale and status_file_data.get("exists"):
+        state, exit_code = "stale", EXIT_NOT_RUNNING
+    elif status_data.get("install_phase") in _STARTING_PHASES:
+        state, exit_code = "starting", EXIT_DEGRADED
+    elif status_data.get("running") is False and status_data.get("message") == "stopped":
+        state, exit_code = "stopped", EXIT_NOT_RUNNING
+    else:
+        state, exit_code = "not_running", EXIT_NOT_RUNNING
+
+    return {
+        "state": state,
+        "exit_code": exit_code,
+        "status_age_seconds": round(age_seconds, 1) if age_seconds is not None else None,
+        "status_stale": stale,
+    }

--- a/src/origin_mcp/tools/bridge.py
+++ b/src/origin_mcp/tools/bridge.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-import json
-import os
-from pathlib import Path
 from typing import Any
 
-from origin_mcp.bridge_client import OriginBridgeConfig, request_bridge
-from origin_mcp.bridge_handshake import read_handshake
-from origin_mcp.errors import OriginBridgeError
-from origin_mcp.logging_config import active_log_path, tail_log
+from origin_mcp.bridge_client import request_bridge
+from origin_mcp.diagnostics import collect_diagnostics, read_bridge_status
 
 from ._shared import (
     COMPACT_TOOL_NAMES,
@@ -20,135 +15,9 @@ from ._shared import (
     client,
 )
 
-
-def _dedupe_strings(values: list[str]) -> list[str]:
-    unique: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        if value not in seen:
-            seen.add(value)
-            unique.append(value)
-    return unique
-
-
-def _status_file_candidates(status_path: str | None = None) -> list[Path]:
-    candidates: list[Path] = []
-    handshake = read_handshake() or {}
-    for value in (
-        status_path,
-        os.environ.get("ORIGIN_MCP_BRIDGE_STATUS"),
-        handshake.get("status_path"),
-    ):
-        if value:
-            candidates.append(Path(value).expanduser())
-    candidates.extend(
-        [
-            Path.cwd() / "origin-bridge.status.txt",
-            Path(__file__).resolve().parents[3] / "origin-bridge.status.txt",
-        ]
-    )
-
-    unique: list[Path] = []
-    seen: set[str] = set()
-    for candidate in candidates:
-        resolved = candidate.resolve()
-        key = os.path.normcase(str(resolved))
-        if key not in seen:
-            seen.add(key)
-            unique.append(resolved)
-    return unique
-
-
-def _read_bridge_status(status_path: str | None = None) -> dict[str, Any]:
-    candidates = _status_file_candidates(status_path)
-    for candidate in candidates:
-        if not candidate.exists():
-            continue
-        try:
-            text = candidate.read_text(encoding="utf-8")
-        except OSError as exc:
-            return {
-                "path": str(candidate),
-                "exists": True,
-                "readable": False,
-                "error": str(exc),
-                "candidates": [str(path) for path in candidates],
-            }
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError:
-            data = None
-        return {
-            "path": str(candidate),
-            "exists": True,
-            "readable": True,
-            "format": "json" if isinstance(data, dict) else "text",
-            "data": data if isinstance(data, dict) else None,
-            "raw_preview": None if isinstance(data, dict) else text[:1000],
-            "candidates": [str(path) for path in candidates],
-        }
-    return {
-        "path": str(candidates[0]) if candidates else None,
-        "exists": False,
-        "readable": False,
-        "candidates": [str(path) for path in candidates],
-    }
-
-
-def _status_runtime_recommendations(status_data: dict[str, Any]) -> list[str]:
-    probe = status_data.get("runtime_probe")
-    if not isinstance(probe, dict):
-        return []
-
-    recommendations: list[str] = []
-    if probe.get("inside_origin", probe.get("likely_origin_embedded_python")) is False:
-        recommendations.append(
-            "The status file does not look like it came from Origin's embedded Python. "
-            "Start addon.py from Origin's Python Console or the Origin MCP Bridge Start App, "
-            "not from a normal terminal Python."
-        )
-    inside_origin = probe.get("inside_origin", probe.get("likely_origin_embedded_python")) is True
-    embedded_api = (
-        probe.get(
-            "embedded_api_available",
-            probe.get("origin_host_api_available"),
-        )
-        is True
-    )
-    if probe.get("originpro_available") is False and not (inside_origin and embedded_api):
-        recommendations.append(
-            "originpro was not importable when addon.py wrote the status file. Start the "
-            "bridge inside Origin, or allow addon.py to install missing runtime dependencies."
-        )
-    return recommendations
-
-
-def _status_diagnostics(status_data: dict[str, Any] | None) -> dict[str, Any]:
-    if not isinstance(status_data, dict):
-        return {}
-    probe = status_data.get("runtime_probe")
-    probe_data = probe if isinstance(probe, dict) else {}
-    return {
-        "message": status_data.get("message"),
-        "running": status_data.get("running"),
-        "install_phase": status_data.get("install_phase"),
-        "last_successful_start": status_data.get("last_successful_start"),
-        "last_error": status_data.get("last_error"),
-        "last_error_type": status_data.get("last_error_type"),
-        "inside_origin": probe_data.get(
-            "inside_origin",
-            probe_data.get("likely_origin_embedded_python"),
-        ),
-        "embedded_api_available": probe_data.get(
-            "embedded_api_available",
-            probe_data.get("origin_host_api_available"),
-        ),
-        "originpro_available": probe_data.get("originpro_available"),
-        "originpro_source": probe_data.get("originpro_source"),
-        "python_executable": status_data.get("python_executable"),
-        "python_version": status_data.get("python_version"),
-        "status_updated_at": status_data.get("updated_at"),
-    }
+# Backward-compatible private alias for callers/tests that inspected the old
+# tool-local helper before diagnostics were shared with the CLI.
+_read_bridge_status = read_bridge_status
 
 
 def _bridge_call(
@@ -258,87 +127,15 @@ def origin_doctor(
     """Diagnose Origin bridge configuration, status file, and connectivity."""
 
     def run() -> dict[str, Any]:
-        config = OriginBridgeConfig.from_env(host=host, port=port, token=token, timeout=timeout)
-        status_file = _read_bridge_status(status_path)
-        bridge_check: dict[str, Any] = {"ok": False}
-        origin_check: dict[str, Any] | None = None
-        recommendations: list[str] = []
-
-        try:
-            response = request_bridge(
-                "ping",
-                host=config.host,
-                port=config.port,
-                token=config.token,
-                timeout=config.timeout,
-            )
-            bridge_check = {"ok": True, "response": response}
-        except OriginBridgeError as exc:
-            bridge_check = {
-                "ok": False,
-                "error_code": exc.error_code,
-                "message": str(exc),
-            }
-            recommendations.append(
-                "Start Origin, open the Python Console, and run the root addon.py."
-            )
-            recommendations.append(
-                "If addon.py is already running, compare ORIGIN_MCP_BRIDGE_HOST and "
-                "ORIGIN_MCP_BRIDGE_PORT with the status file."
-            )
-
-        if ping_origin and bridge_check["ok"]:
-            try:
-                origin_check = {
-                    "ok": True,
-                    "response": request_bridge(
-                        "origin_ping",
-                        {"show": True},
-                        host=config.host,
-                        port=config.port,
-                        token=config.token,
-                        timeout=max(float(config.timeout), 10.0),
-                    ),
-                }
-            except OriginBridgeError as exc:
-                origin_check = {
-                    "ok": False,
-                    "error_code": exc.error_code,
-                    "message": str(exc),
-                }
-                recommendations.append(
-                    "The bridge responded, but Origin automation failed. Check the live Origin "
-                    "session and the status file last_error field."
-                )
-
-        status_data = status_file.get("data")
-        if isinstance(status_data, dict) and status_data.get("last_error"):
-            recommendations.append(
-                "addon.py recorded last_error in the status file; inspect that field first."
-            )
-        if isinstance(status_data, dict):
-            recommendations.extend(_status_runtime_recommendations(status_data))
-        if not status_file.get("exists"):
-            recommendations.append(
-                "No bridge status file was found. Set ORIGIN_MCP_BRIDGE_STATUS or start addon.py "
-                "from the checkout root."
-            )
-
-        log_path = active_log_path()
-        log_info: dict[str, Any] = {
-            "path": str(log_path) if log_path else None,
-            "enabled": log_path is not None,
-            "exists": bool(log_path and log_path.exists()),
-            "recent": tail_log(20) if log_path and log_path.exists() else [],
-        }
-
-        return _ok(
-            "Origin doctor completed.",
-            config={
-                "host": config.host,
-                "port": config.port,
-                "timeout": config.timeout,
-                "token_configured": bool(config.token),
+        diagnostics = collect_diagnostics(
+            host=host,
+            port=port,
+            token=token,
+            timeout=timeout,
+            status_path=status_path,
+            ping_origin=ping_origin,
+            request_fn=request_bridge,
+            config_metadata={
                 "tool_profile": _tool_profile(),
                 "compact_tool_count": len(COMPACT_TOOL_NAMES),
                 "compact_tools": sorted(COMPACT_TOOL_NAMES),
@@ -346,23 +143,9 @@ def origin_doctor(
                     name: len(tools) for name, tools in PROFILE_TOOL_NAMES.items()
                 },
                 "full_profile_aliases": ["full", "expert", "all"],
-                "env": {
-                    "ORIGIN_MCP_BRIDGE_HOST": os.environ.get("ORIGIN_MCP_BRIDGE_HOST"),
-                    "ORIGIN_MCP_BRIDGE_PORT": os.environ.get("ORIGIN_MCP_BRIDGE_PORT"),
-                    "ORIGIN_MCP_BRIDGE_TIMEOUT": os.environ.get("ORIGIN_MCP_BRIDGE_TIMEOUT"),
-                    "ORIGIN_MCP_BRIDGE_STATUS": os.environ.get("ORIGIN_MCP_BRIDGE_STATUS"),
-                    "ORIGIN_MCP_BRIDGE_TOKEN": bool(os.environ.get("ORIGIN_MCP_BRIDGE_TOKEN")),
-                    "ORIGIN_MCP_TOOL_PROFILE": os.environ.get("ORIGIN_MCP_TOOL_PROFILE"),
-                    "ORIGIN_MCP_LOG_FILE": os.environ.get("ORIGIN_MCP_LOG_FILE"),
-                },
             },
-            status_file=status_file,
-            status_diagnostics=_status_diagnostics(status_data),
-            bridge=bridge_check,
-            origin=origin_check,
-            log=log_info,
-            recommendations=_dedupe_strings(recommendations),
         )
+        return _ok("Origin doctor completed.", **diagnostics)
 
     return _wrap(run)
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -12,6 +12,7 @@ import pytest
 
 import origin_mcp.bridge as bridge
 import origin_mcp.bridge_client as bridge_client_module
+import origin_mcp.diagnostics as diagnostics
 import origin_mcp.logging_config as bridge_logging
 import origin_mcp.server as mcp_server
 import origin_mcp.tools.bridge as bridge_tools
@@ -210,7 +211,7 @@ def test_doctor_prefers_status_path_published_in_handshake(
 ) -> None:
     current = tmp_path / "current-status.json"
     current.write_text('{"running": true, "message": "current"}', encoding="utf-8")
-    monkeypatch.setattr(bridge_tools, "read_handshake", lambda: {"status_path": str(current)})
+    monkeypatch.setattr(diagnostics, "read_handshake", lambda: {"status_path": str(current)})
 
     result = bridge_tools._read_bridge_status()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+import origin_mcp.cli as cli
+import origin_mcp.diagnostics as diagnostics
+from origin_mcp.diagnostics import (
+    EXIT_DEGRADED,
+    EXIT_DIAGNOSTIC_ERROR,
+    EXIT_HEALTHY,
+    EXIT_NOT_RUNNING,
+    classify_diagnostics,
+    status_file_candidates,
+)
+
+
+def diagnostic_report(
+    *,
+    bridge_ok: bool,
+    origin: dict[str, Any] | None = None,
+    status_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "config": {"host": "127.0.0.1", "port": 47631, "timeout": 2.0},
+        "bridge": (
+            {"ok": True, "response": {"bridge": "origin-mcp-bridge"}}
+            if bridge_ok
+            else {
+                "ok": False,
+                "error_code": "origin_bridge_unavailable",
+                "message": "connection refused",
+            }
+        ),
+        "origin": origin,
+        "status_file": {
+            "path": r"C:\Temp\origin-mcp\status.json",
+            "exists": status_data is not None,
+            "readable": status_data is not None,
+            "data": status_data,
+        },
+        "status_diagnostics": status_data or {},
+        "log": {"enabled": True, "exists": False, "path": r"C:\Temp\bridge.log"},
+        "recommendations": ["Click the Origin MCP Bridge Start App."],
+    }
+
+
+def test_cli_without_arguments_starts_mcp_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = False
+
+    def fake_server_main() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("origin_mcp.server.main", fake_server_main)
+
+    assert cli.main([]) == EXIT_HEALTHY
+    assert called is True
+
+
+def test_status_prints_human_summary(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    report = diagnostic_report(bridge_ok=True)
+    monkeypatch.setattr(cli, "collect_diagnostics", lambda **_kwargs: report)
+
+    exit_code = cli.main(["status"])
+    output = capsys.readouterr().out
+
+    assert exit_code == EXIT_HEALTHY
+    assert "Origin MCP bridge: RUNNING" in output
+    assert "Bridge: reachable" in output
+    assert "Address: 127.0.0.1:47631" in output
+
+
+def test_status_json_reports_not_running(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    report = diagnostic_report(bridge_ok=False)
+    monkeypatch.setattr(cli, "collect_diagnostics", lambda **_kwargs: report)
+
+    exit_code = cli.main(["status", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == EXIT_NOT_RUNNING
+    assert payload["state"] == "not_running"
+    assert payload["exit_code"] == EXIT_NOT_RUNNING
+    assert payload["diagnostics"]["bridge"]["ok"] is False
+
+
+def test_doctor_forwards_ping_origin_and_reports_degraded(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    captured: dict[str, Any] = {}
+    report = diagnostic_report(
+        bridge_ok=True,
+        origin={
+            "ok": False,
+            "error_code": "origin_operation_failed",
+            "message": "Origin is busy",
+        },
+    )
+
+    def fake_collect(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return report
+
+    monkeypatch.setattr(cli, "collect_diagnostics", fake_collect)
+
+    exit_code = cli.main(["doctor", "--ping-origin"])
+    output = capsys.readouterr().out
+
+    assert exit_code == EXIT_DEGRADED
+    assert captured["ping_origin"] is True
+    assert "Origin MCP doctor: DEGRADED" in output
+    assert "Origin: failed (origin_operation_failed)" in output
+
+
+def test_diagnostics_command_failure_has_stable_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    def fail(**_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("bad configuration")
+
+    monkeypatch.setattr(cli, "collect_diagnostics", fail)
+
+    exit_code = cli.main(["doctor", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == EXIT_DIAGNOSTIC_ERROR
+    assert payload == {
+        "state": "diagnostic_error",
+        "exit_code": EXIT_DIAGNOSTIC_ERROR,
+        "error_type": "RuntimeError",
+        "message": "bad configuration",
+    }
+
+
+def test_status_candidates_include_installed_start_app(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr("origin_mcp.diagnostics.read_handshake", lambda: None)
+
+    candidates = status_file_candidates()
+
+    expected = (
+        local_appdata
+        / "OriginLab"
+        / "Apps"
+        / "Origin MCP Bridge Start"
+        / "origin-bridge.status.txt"
+    ).resolve()
+    assert expected in candidates
+
+
+def test_read_status_prefers_newest_conventional_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    older = tmp_path / "older.json"
+    newer = tmp_path / "newer.json"
+    older.write_text('{"message": "older"}', encoding="utf-8")
+    newer.write_text('{"message": "newer"}', encoding="utf-8")
+    os.utime(older, (1, 1))
+    os.utime(newer, (2, 2))
+    monkeypatch.setattr(diagnostics, "status_file_candidates", lambda _path=None: [older, newer])
+    monkeypatch.setattr(
+        diagnostics,
+        "_configured_status_file_candidates",
+        lambda _path=None: [],
+    )
+
+    result = diagnostics.read_bridge_status()
+
+    assert result["path"] == str(newer)
+    assert result["data"]["message"] == "newer"
+
+
+@pytest.mark.parametrize(
+    ("status_data", "expected_state", "expected_exit"),
+    [
+        ({"install_phase": "checking_dependencies"}, "starting", EXIT_DEGRADED),
+        (
+            {"install_phase": "failed", "last_error": "pip failed"},
+            "failed",
+            EXIT_DEGRADED,
+        ),
+        ({"running": False, "message": "stopped"}, "stopped", EXIT_NOT_RUNNING),
+        (
+            {"updated_at": "2026-01-01T00:00:00Z"},
+            "stale",
+            EXIT_NOT_RUNNING,
+        ),
+    ],
+)
+def test_classify_non_running_states(
+    status_data: dict[str, Any],
+    expected_state: str,
+    expected_exit: int,
+) -> None:
+    report = diagnostic_report(bridge_ok=False, status_data=status_data)
+
+    result = classify_diagnostics(
+        report,
+        now=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+
+    assert result["state"] == expected_state
+    assert result["exit_code"] == expected_exit


### PR DESCRIPTION
## Summary

- add `origin-mcp status` and `origin-mcp doctor --ping-origin` with human-readable and JSON output
- share bridge diagnostics between the CLI and MCP `origin_doctor` tool
- classify running, starting, stopped, stale, failed, and degraded states with stable exit codes
- prefer the newest conventional status file after the handshake is cleared
- unify `python -m origin_mcp` with the CLI while preserving no-argument stdio server startup
- correct the Start/Stop App documentation and improve the Chinese README

## Why

Users previously needed an active MCP client to diagnose the bridge, and stale status files could obscure the actual Origin App lifecycle state. The documentation also described a single toggle even though reliable foreground serving requires separate Start and Stop App entries.

## User impact

Users and agents can now check bridge health directly from a terminal, consume structured JSON, and distinguish a stopped bridge from startup failures or stale state. Existing MCP configurations remain compatible.

## Validation

- `python scripts/dev_check.py --tests`
- Ruff check and format: passed
- mypy: passed
- pytest: 673 passed
- real Origin lifecycle: start → status/doctor → stop → status → restart
- live `doctor --ping-origin`: bridge and Origin both reachable