### PR TITLE
Improve smart plot styling and adaptive layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Development and debugging rules
+
+## Origin Start/Stop App
+
+- Treat the installed Origin Start/Stop App as a generated artifact. When a
+  change affects `addon.py`, the App launcher/installer/build scripts, or any
+  `origin_mcp` code executed by the Origin-side bridge, do not test against a
+  previously installed App.
+- Before the real-Origin verification, stop the running bridge and rebuild and
+  overwrite the local App installation:
+
+  ```powershell
+  python scripts\build_origin_app.py --force --install
+  ```
+
+- Start **Origin MCP Bridge Start** again after installation, then verify the
+  live connection with `origin-mcp status` and
+  `origin-mcp doctor --ping-origin`.
+- Repacking and reinstalling both OPX files is required when testing App
+  packaging, metadata, registration, or distributable installation. For normal
+  local source debugging of an already registered App, overwriting the App
+  folders with `--install` is sufficient.

--- a/docs/origin-ui-buttons.md
+++ b/docs/origin-ui-buttons.md
@@ -27,6 +27,24 @@ folder in one step:
 python scripts\build_origin_app.py --force --install
 ```
 
+### Development update rule
+
+The installed Start App vendors its own copy of the `origin_mcp` package.
+Therefore, whenever development changes affect `addon.py`, the App
+launcher/installer/build scripts, or code executed by the Origin-side bridge,
+stop the bridge and run the command above again before testing with Origin.
+Restart **Origin MCP Bridge Start**, then verify the connection with:
+
+```powershell
+origin-mcp status
+origin-mcp doctor --ping-origin
+```
+
+For an App that is already registered on the development machine,
+`--force --install` is enough for normal source debugging. Repack and reinstall
+both OPX files when validating App packaging, metadata, registration, or a
+distributable installation.
+
 This creates `build\origin-app\Origin MCP Bridge Start` and
 `build\origin-app\Origin MCP Bridge Stop`, then copies both source folders to
 `%LOCALAPPDATA%\OriginLab\Apps`. As with the installed-package workflow, pack

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -238,6 +238,58 @@ annotations 18 pt. FigureSpec annotations use the same 18 pt default unless
 `style.annotation_font_size` or an individual annotation `style.font_size`
 overrides it.
 
+Table plotting also applies readability defaults when the caller does not
+provide an explicit override. Machine-oriented headers such as
+`measured_response`, `duration_s`, and `dose_uM` are written to worksheet Long
+Name labels as `Measured response`, `Duration (s)`, and `Dose (µM)`. Common unit
+symbols use Origin Unicode escape notation so they survive export. A shared
+conservative rule resolver profiles chart family, series count, row count,
+category-label length, and numeric range. It hides redundant single-series
+legends, retains multi-series legends, moves line/scatter legends to the quieter
+upper corner, rotates crowded category ticks, selects scientific notation only
+for extreme magnitudes, keeps nonnegative bar-like charts on a zero baseline,
+and reduces marker size while increasing transparency for dense scatter plots.
+Plots with long categorical X labels remain vertically oriented; their page
+height and bottom margin grow automatically so rotated labels are not clipped.
+The height is set from a target page aspect ratio, so repeated formatting does
+not keep increasing the page size.
+Axis titles are inferred from field semantics instead of concatenating every
+series name. Fields such as `temperature_C`, `temperature_mean_C`, and
+`temperature_std_C` produce the shared axis title `Temperature (°C)`, while
+`Mean` and `SD` remain available as legend labels. Wide fields such as
+`glucose_control_mg_dL` and `glucose_treated_mg_dL` produce
+`Glucose (mg/dL)` with compact `Control` and `Treated` legend entries. Tidy
+`value`/`unit` data can also use a constant `metric`, `measure`, `measurement`,
+`variable`, or `parameter` column to recover the metric name and unit.
+
+Dual-Y plots infer the left and right titles independently from the columns
+assigned to each axis. Explicit `x_label`, `y_label`, `y1_label`, and `y2_label`
+values always take precedence. For line and scatter charts, legend placement
+first estimates the legend footprint and checks all four inside corners against
+the plotted data. Each Y-axis group is normalized independently so dual-axis
+units do not distort the occupancy test. The quietest data-free corner is used
+when it fits. Only when every candidate intersects data, or the legend footprint
+is too large, does it move to a reserved column outside the plot; the page then
+widens and the right margin grows so the legend does not cover data or clip
+during export.
+Each graph response includes `visual_defaults` with the selected values and the
+reason for every choice. Explicit `show_legend` and `palette_name` arguments
+take precedence.
+
+When `style_mode="nature"` and no palette is specified, table plotting uses
+`lcpmgh_auto` to choose an installed lcpmgh/colors palette whose color count
+matches the number of plotted series. Dedicated table plotting tools and the
+parameterized `origin_plot` entry point accept `palette_name`; an explicit
+registered palette name always overrides automatic selection. Origin or custom
+template palettes remain untouched in `origin_default` mode.
+
+Distribution and field-color tools use safer visual defaults: histograms choose
+a bounded Freedman-Diaconis bin width unless `bin_width` or a custom template is
+provided, and histogram/box/heatmap legends are hidden by default. Heatmaps use
+the perceptually uniform `viridis` colormap unless `colormap` or a custom
+template is supplied. Explicit arguments and FigureSpec plot styles always take
+precedence over these defaults.
+
 For existing plots, `origin_set_plot_style` controls color, line width/style,
 symbols, transparency, column/bar width, colormaps, contour levels and color
 scale limits, histogram bin width, error-bar cap width, and box-chart width on

--- a/src/origin_mcp/bridge_client.py
+++ b/src/origin_mcp/bridge_client.py
@@ -385,6 +385,7 @@ def _deserialize_bridge_value(value: Any) -> Any:
                 style_mode=data.get("style_mode", "origin_default"),
                 requested_graph_name=data.get("requested_graph_name"),
                 display_name=data.get("display_name"),
+                visual_defaults=data.get("visual_defaults"),
             )
         if value_type == "Path":
             return Path(str(value["value"]))

--- a/src/origin_mcp/chart_palette.py
+++ b/src/origin_mcp/chart_palette.py
@@ -10,6 +10,9 @@ historical ``self._nature_palette()`` access pattern keeps working.
 
 from __future__ import annotations
 
+import colorsys
+import itertools
+import math
 import os
 from typing import Any
 
@@ -220,8 +223,60 @@ def select_palette_for_count(plot_count: int) -> tuple[str, dict[str, Any]]:
     ]
     if not matches:
         raise OriginOperationError(f"No lcpmgh/colors palette is available for {target} colors.")
-    matches.sort(key=lambda item: int(item[1].get("source_index") or 0))
+    # The source catalog is ordered for browsing rather than for plotting on a
+    # white page. Rank exact-count palettes by legibility and hue separation so
+    # ``lcpmgh_auto`` does not accidentally choose a nearly white first match.
+    matches.sort(
+        key=lambda item: (
+            -_palette_readability_score(item[1]),
+            int(item[1].get("source_index") or 0),
+        )
+    )
     return matches[0]
+
+
+def _palette_readability_score(palette: dict[str, Any]) -> float:
+    colors = [_rgb(color) for color in palette.get("palette", [])]
+    if not colors:
+        return float("-inf")
+    contrasts = [_contrast_against_white(color) for color in colors]
+    distances = [
+        math.dist(first, second) / math.sqrt(3 * 255**2)
+        for first, second in itertools.combinations(colors, 2)
+    ]
+    hue_coverage = _palette_hue_coverage(colors)
+    return (
+        min(min(contrasts), 3.0) * 1.5
+        + sum(min(contrast, 7.0) for contrast in contrasts) / len(contrasts) * 0.5
+        + (sum(distances) / len(distances) if distances else 0.0) * 4.0
+        + hue_coverage / 60.0
+    )
+
+
+def _contrast_against_white(color: Rgb) -> float:
+    channels = [channel / 255 for channel in color]
+    linear = [
+        channel / 12.92
+        if channel <= 0.04045
+        else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    luminance = 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+    return 1.05 / (luminance + 0.05)
+
+
+def _palette_hue_coverage(colors: list[Rgb]) -> float:
+    hues = []
+    for red, green, blue in colors:
+        hue, saturation, _value = colorsys.rgb_to_hsv(red / 255, green / 255, blue / 255)
+        if saturation >= 0.15:
+            hues.append(hue * 360)
+    if len(hues) < 2:
+        return 0.0
+    hues.sort()
+    gaps = [second - first for first, second in itertools.pairwise(hues)]
+    gaps.append(360 - hues[-1] + hues[0])
+    return 360 - max(gaps)
 
 
 def auto_palette_notice(plot_count: int, palette_name: str) -> dict[str, Any]:

--- a/src/origin_mcp/chart_palette.py
+++ b/src/origin_mcp/chart_palette.py
@@ -256,9 +256,7 @@ def _palette_readability_score(palette: dict[str, Any]) -> float:
 def _contrast_against_white(color: Rgb) -> float:
     channels = [channel / 255 for channel in color]
     linear = [
-        channel / 12.92
-        if channel <= 0.04045
-        else ((channel + 0.055) / 1.055) ** 2.4
+        channel / 12.92 if channel <= 0.04045 else ((channel + 0.055) / 1.055) ** 2.4
         for channel in channels
     ]
     luminance = 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]

--- a/src/origin_mcp/client/base.py
+++ b/src/origin_mcp/client/base.py
@@ -49,6 +49,7 @@ TABLE_WORKSHEET_PLOT_IDS = {
     214,
     215,
     216,
+    219,
     225,
     249,
 }

--- a/src/origin_mcp/client/graph_formatting_helpers.py
+++ b/src/origin_mcp/client/graph_formatting_helpers.py
@@ -385,10 +385,7 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
         y_upper = f"layer.y.to-(layer.y.to-layer.y.from)*{margin:.6g}-legend.dy/2"
         y_lower = f"layer.y.from+(layer.y.to-layer.y.from)*{margin:.6g}+legend.dy/2"
         if position == "outside_right":
-            x_expr = (
-                "layer.x.to+(layer.x.to-layer.x.from)*"
-                f"{max(margin, 0.04):.6g}+legend.dx/2"
-            )
+            x_expr = f"layer.x.to+(layer.x.to-layer.x.from)*{max(margin, 0.04):.6g}+legend.dx/2"
             y_expr = "layer.y.to-legend.dy/2"
             return self._legend_position_script(graph_name, layer_index, x_expr, y_expr)
         x_expr = x_right if position.endswith("_right") else x_left

--- a/src/origin_mcp/client/graph_formatting_helpers.py
+++ b/src/origin_mcp/client/graph_formatting_helpers.py
@@ -341,6 +341,8 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
             "lower_right": "inside_lower_right",
             "bottom_right": "inside_lower_right",
             "inside_bottom_right": "inside_lower_right",
+            "right": "outside_right",
+            "outside-right": "outside_right",
         }
         normalized = aliases.get(normalized, normalized)
         supported = {
@@ -348,6 +350,7 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
             "inside_upper_right",
             "inside_lower_left",
             "inside_lower_right",
+            "outside_right",
         }
         if normalized not in supported:
             raise OriginOperationError(
@@ -381,6 +384,13 @@ class _GraphFormattingHelperMixin(_OriginClientBase):
         x_right = f"layer.x.to-(layer.x.to-layer.x.from)*{margin:.6g}-legend.dx/2"
         y_upper = f"layer.y.to-(layer.y.to-layer.y.from)*{margin:.6g}-legend.dy/2"
         y_lower = f"layer.y.from+(layer.y.to-layer.y.from)*{margin:.6g}+legend.dy/2"
+        if position == "outside_right":
+            x_expr = (
+                "layer.x.to+(layer.x.to-layer.x.from)*"
+                f"{max(margin, 0.04):.6g}+legend.dx/2"
+            )
+            y_expr = "layer.y.to-legend.dy/2"
+            return self._legend_position_script(graph_name, layer_index, x_expr, y_expr)
         x_expr = x_right if position.endswith("_right") else x_left
         y_expr = y_lower if "_lower_" in position else y_upper
         return self._legend_position_script(graph_name, layer_index, x_expr, y_expr)

--- a/src/origin_mcp/client/graph_style.py
+++ b/src/origin_mcp/client/graph_style.py
@@ -77,9 +77,7 @@ class _GraphStyleMixin(_OriginClientBase):
                     self._set_origin_property(plot, "symbol_size", actual_symbol_size)
                 role = roles[global_plot_index]
                 color = (
-                    semantic_palette[role]
-                    if role
-                    else palette[global_plot_index % len(palette)]
+                    semantic_palette[role] if role else palette[global_plot_index % len(palette)]
                 )
                 self._set_origin_property(plot, "color", color)
                 try:

--- a/src/origin_mcp/client/graph_style.py
+++ b/src/origin_mcp/client/graph_style.py
@@ -65,23 +65,29 @@ class _GraphStyleMixin(_OriginClientBase):
         actual_symbol_size = chart_style["symbol_size"]
         styled_plots = 0
         applied_roles: list[str] = []
+        roles = self._palette_roles(palette_role, total_plots, palette_name_actual)
+        global_plot_index = 0
         for index in indexes:
             layer = self._graph_layer(graph, index)
             plots = self._layer_plots(layer)
-            roles = self._palette_roles(palette_role, len(plots), palette_name_actual)
-            for plot_index, plot in enumerate(plots):
+            for plot in plots:
                 if actual_line_width is not None:
                     self._set_nature_plot_line_width(plot, actual_line_width)
                 if actual_symbol_size is not None:
                     self._set_origin_property(plot, "symbol_size", actual_symbol_size)
-                role = roles[plot_index]
-                color = semantic_palette[role] if role else palette[plot_index % len(palette)]
+                role = roles[global_plot_index]
+                color = (
+                    semantic_palette[role]
+                    if role
+                    else palette[global_plot_index % len(palette)]
+                )
                 self._set_origin_property(plot, "color", color)
                 try:
                     self._set_origin_property(plot, "transparency", 0)
                 except OriginOperationError:
                     pass
-                applied_roles.append(role or f"category_{plot_index + 1}")
+                applied_roles.append(role or f"category_{global_plot_index + 1}")
+                global_plot_index += 1
             styled_plots += len(plots)
 
         safe_font = self._escape_labtalk(font_family)
@@ -166,11 +172,13 @@ class _GraphStyleMixin(_OriginClientBase):
                 response["diagnostics"]["auto_palette"] = auto_palette
         return response
 
-    def _nature_axis_title_text(self, layer: Any, axis_name: str, safe_font: str) -> str:
+    def _nature_axis_title_text(self, layer: Any, axis_name: str, _safe_font: str) -> str:
         axis = layer.axis(axis_name)
         title = self._safe_origin_attr(axis, "title")
-        text = self._labtalk_text(str(title or "")).replace('"', '\\"').replace(")", r"\)")
-        return f"\\f:{safe_font}({text})"
+        # Font is assigned independently through xb.font/yl.font. Keeping the
+        # title literal here prevents nested Origin escapes such as \x(00B5)
+        # from being corrupted when a surrounding \f:Font(...) group is built.
+        return self._labtalk_text(str(title or "")).replace('"', '\\"')
 
     def _set_nature_plot_line_width(self, plot: Any, line_width: float) -> None:
         self._set_plot_line_width(plot, line_width)

--- a/src/origin_mcp/client/table_plot.py
+++ b/src/origin_mcp/client/table_plot.py
@@ -4,7 +4,13 @@ from pathlib import Path
 from typing import Any
 
 from .. import template_library
-from ..errors import OriginOperationError
+from ..errors import OriginMcpError, OriginOperationError
+from ..text_format import humanize_field_name
+from ..visual_defaults import (
+    automatic_histogram_bin_width,
+    decision_value,
+    resolve_visual_defaults,
+)
 from .base import (
     MATRIX_PLOTM_IDS,
     TABLE_PLOTXYZ_IDS,
@@ -13,6 +19,8 @@ from .base import (
     WorksheetRef,
     _OriginClientBase,
 )
+
+DUAL_Y_NATURE_AXIS_TITLE_SIZE = 20
 
 
 class _TablePlotMixin(_OriginClientBase):
@@ -75,9 +83,10 @@ class _TablePlotMixin(_OriginClientBase):
         z_col: str | int | None = None,
         y_error_col: str | int | None = None,
         x_error_col: str | int | None = None,
-        show_legend: bool = True,
+        show_legend: bool | None = None,
         style_mode: str = "origin_default",
         palette_name: str | None = None,
+        histogram_bin_width: float | str | None = None,
         export_path: Path | None = None,
     ) -> tuple[WorksheetRef, GraphRef]:
         path = self._normalize_user_path(path)
@@ -119,6 +128,25 @@ class _TablePlotMixin(_OriginClientBase):
         wks.from_df(df)
 
         style_mode_actual = self._normalize_style_mode(style_mode)
+        visual_defaults = resolve_visual_defaults(
+            chart_type=kind,
+            series_count=len(y_names),
+            row_count=len(df),
+            x_values=df[x_name].to_numpy(),
+            y_series=[df[name].to_numpy() for name in y_names],
+            show_legend=show_legend,
+            palette_name=palette_name,
+            style_mode=style_mode_actual,
+            x_name=x_name,
+            y_names=y_names,
+            table=df,
+            title_hint=title,
+            x_label=x_label,
+            y_label=y_label,
+        )
+        show_legend_actual = bool(
+            decision_value(visual_defaults, "legend", "show")
+        )
         graph_template = self._resolve_graph_template(kind=kind, template=template)
         graph = self._new_graph(kind=kind, graph_name=graph_name, template=graph_template)
         layer = graph[0] if hasattr(graph, "__getitem__") else graph
@@ -135,6 +163,18 @@ class _TablePlotMixin(_OriginClientBase):
                 x_error_name=xerr_name,
             )
 
+        # Add plots while Origin can still resolve the imported DataFrame
+        # headers. Some Origin builds silently add zero plots when ``colx`` or
+        # ``coly`` is addressed by the original header after the worksheet Long
+        # Name row has been changed. Display labels are safe to apply once the
+        # plot data ranges have already been bound.
+        series_labels = decision_value(visual_defaults, "legend", "series_labels")
+        self._set_worksheet_display_labels(
+            wks,
+            columns,
+            overrides=dict(zip(y_names, series_labels, strict=True)),
+        )
+
         actual_graph_name = self._object_name(graph, default=graph_name or "Graph")
         if kind in {"column", "c"} and len(y_names) > 1:
             self._group_layer_plots(layer, graph_name=actual_graph_name, layer_index=0)
@@ -142,9 +182,9 @@ class _TablePlotMixin(_OriginClientBase):
         self.format_graph(
             graph=graph,
             title=title,
-            x_label=x_label or x_name,
-            y_label=y_label or ", ".join(y_names),
-            show_legend=show_legend,
+            x_label=decision_value(visual_defaults, "axes", "x_title"),
+            y_label=decision_value(visual_defaults, "axes", "y_title"),
+            show_legend=show_legend_actual,
             rescale=True,
         )
         self._remember_graph_alias(graph_name, actual_graph_name)
@@ -152,10 +192,33 @@ class _TablePlotMixin(_OriginClientBase):
             style_kwargs: dict[str, Any] = {
                 "graph_name": actual_graph_name,
                 "chart_type": kind,
+                "show_legend": show_legend_actual,
+                "palette_name": decision_value(visual_defaults, "palette_name"),
             }
-            if palette_name is not None:
-                style_kwargs["palette_name"] = palette_name
             self.apply_nature_style(**style_kwargs)
+        if kind == "histogram":
+            resolved_bin_width = histogram_bin_width
+            if histogram_bin_width == "auto" or (
+                histogram_bin_width is None and template is None
+            ):
+                resolved_bin_width = automatic_histogram_bin_width(df[y_names[0]].to_numpy())
+            if resolved_bin_width is not None:
+                if not isinstance(resolved_bin_width, (int, float)) or resolved_bin_width <= 0:
+                    raise OriginOperationError(
+                        "histogram_bin_width must be a positive number or 'auto'."
+                    )
+                self.set_plot_style(
+                    graph_name=actual_graph_name,
+                    histogram_bin_width=float(resolved_bin_width),
+                )
+                # Origin keeps the Y limits from its initial automatic binning.
+                # Recompute the axes after changing the bin width so count bars
+                # are not clipped against the old (often 0..1.1) range.
+                self._rescale(layer)
+        visual_defaults["applied"] = self._apply_smart_visual_defaults(
+            graph_name=actual_graph_name,
+            defaults=visual_defaults,
+        )
         exported: str | None = None
         if export_path is not None:
             exported = self._export_plot_command_graph(export_path, actual_graph_name)["path"]
@@ -168,6 +231,7 @@ class _TablePlotMixin(_OriginClientBase):
             style_mode=style_mode_actual,
             requested_graph_name=graph_name,
             display_name=self._object_long_name(graph, default=graph_name),
+            visual_defaults=visual_defaults,
         )
 
     def plot_dual_y(
@@ -191,7 +255,9 @@ class _TablePlotMixin(_OriginClientBase):
         y1_label: str | None = None,
         y2_label: str | None = None,
         plot_type: str = "line",
+        show_legend: bool | None = None,
         style_mode: str = "origin_default",
+        palette_name: str | None = None,
         export_path: Path | None = None,
     ) -> tuple[WorksheetRef, GraphRef]:
         if not y1_cols or not y2_cols:
@@ -219,6 +285,25 @@ class _TablePlotMixin(_OriginClientBase):
         y1_names = [self._resolve_column(columns, col, default_index=1) for col in y1_cols]
         y2_names = [self._resolve_column(columns, col, default_index=1) for col in y2_cols]
         style_mode_actual = self._normalize_style_mode(style_mode)
+        visual_defaults = resolve_visual_defaults(
+            chart_type=plot_type,
+            series_count=len(y1_names) + len(y2_names),
+            row_count=len(df),
+            x_values=df[x_name].to_numpy(),
+            y_series=[df[name].to_numpy() for name in y1_names + y2_names],
+            show_legend=show_legend,
+            palette_name=palette_name,
+            style_mode=style_mode_actual,
+            x_name=x_name,
+            y_names=y1_names,
+            y2_names=y2_names,
+            table=df,
+            title_hint=title,
+            x_label=x_label,
+            y_label=y1_label,
+            y2_label=y2_label,
+        )
+        show_legend_actual = bool(decision_value(visual_defaults, "legend", "show"))
 
         actual_book_name = book_name or (
             self._safe_filename(f"{graph_name}_Data") if graph_name else None
@@ -237,22 +322,53 @@ class _TablePlotMixin(_OriginClientBase):
         for y_name in y2_names:
             self._add_plot(layer_right, wks, x_name=x_name, y_name=y_name, kind=plot_type)
 
-        actual_graph_name = self._object_name(graph, default=graph_name or "Graph")
-        if len(y1_names) > 1:
-            self._group_layer_plots(layer_left, graph_name=actual_graph_name, layer_index=0)
-        if len(y2_names) > 1:
-            self._group_layer_plots(layer_right, graph_name=actual_graph_name, layer_index=1)
+        series_labels = decision_value(visual_defaults, "legend", "series_labels")
+        self._set_worksheet_display_labels(
+            wks,
+            columns,
+            overrides=dict(zip(y1_names + y2_names, series_labels, strict=True)),
+        )
 
-        layer_left.axis("x").title = self._label_text(x_label or x_name)
-        layer_left.axis("y").title = self._label_text(y1_label or ", ".join(y1_names))
-        layer_right.axis("y").title = self._label_text(y2_label or ", ".join(y2_names))
+        actual_graph_name = self._object_name(graph, default=graph_name or "Graph")
+        layer_left.axis("x").title = self._label_text(
+            decision_value(visual_defaults, "axes", "x_title")
+        )
+        layer_left.axis("y").title = self._label_text(
+            decision_value(visual_defaults, "axes", "y_title")
+        )
+        layer_right.axis("y").title = self._label_text(
+            decision_value(visual_defaults, "axes", "y2_title")
+        )
         if title:
             self._set_page_long_name(graph, title, force_labtalk=graph_name is not None)
         self._rescale(layer_left)
         self._rescale(layer_right)
         self._remember_graph_alias(graph_name, actual_graph_name)
         if style_mode_actual == "nature":
-            self.apply_nature_style(graph_name=actual_graph_name, chart_type=plot_type)
+            self.apply_nature_style(
+                graph_name=actual_graph_name,
+                chart_type=plot_type,
+                show_legend=show_legend_actual,
+                palette_name=decision_value(visual_defaults, "palette_name"),
+            )
+        try:
+            self.format_graph(
+                graph_name=actual_graph_name,
+                show_legend=show_legend_actual,
+                rescale=False,
+            )
+        except OriginMcpError:
+            pass
+        visual_defaults["applied"] = self._apply_smart_visual_defaults(
+            graph_name=actual_graph_name,
+            defaults=visual_defaults,
+        )
+        visual_defaults["applied"]["dual_y_titles"] = self._sync_dual_y_axis_titles(
+            graph_name=actual_graph_name,
+            left_title=decision_value(visual_defaults, "axes", "y_title"),
+            right_title=decision_value(visual_defaults, "axes", "y2_title"),
+            style_mode=style_mode_actual,
+        )
 
         exported: str | None = None
         if export_path is not None:
@@ -266,7 +382,45 @@ class _TablePlotMixin(_OriginClientBase):
             style_mode=style_mode_actual,
             requested_graph_name=graph_name,
             display_name=self._object_long_name(graph, default=graph_name),
+            visual_defaults=visual_defaults,
         )
+
+    def _sync_dual_y_axis_titles(
+        self,
+        *,
+        graph_name: str,
+        left_title: str,
+        right_title: str,
+        style_mode: str,
+    ) -> dict[str, Any]:
+        """Synchronize the visible title objects used by Origin's doubleY template."""
+
+        safe_graph = self._escape_labtalk(graph_name)
+        safe_left = self._labtalk_text(left_title).replace('"', '\\"')
+        safe_right = self._labtalk_text(right_title).replace('"', '\\"')
+        parts = [
+            f'win -a "{safe_graph}";',
+            "layer -s 1;",
+            f'yl.text$="{safe_left}";',
+            "layer -s 2;",
+            f'yr.text$="{safe_right}";',
+        ]
+        if style_mode == "nature":
+            parts.extend(
+                [
+                    "layer -s 1;",
+                    "yl.font=font(Arial);",
+                    f"yl.fsize={DUAL_Y_NATURE_AXIS_TITLE_SIZE};",
+                    "layer -s 2;",
+                    "yr.font=font(Arial);",
+                    f"yr.fsize={DUAL_Y_NATURE_AXIS_TITLE_SIZE};",
+                ]
+            )
+        script = " ".join(parts)
+        try:
+            return {"script": script, **self.run_labtalk(script)}
+        except OriginMcpError as exc:
+            return {"script": script, "warning": str(exc)}
 
     def plot_table_by_id(
         self,
@@ -287,8 +441,11 @@ class _TablePlotMixin(_OriginClientBase):
         title: str | None = None,
         x_label: str | None = None,
         y_label: str | None = None,
+        show_legend: bool | None = None,
         style_mode: str = "origin_default",
         palette_name: str | None = None,
+        colormap: str | None = None,
+        histogram_bin_width: float | str | None = None,
         export_path: Path | None = None,
     ) -> tuple[WorksheetRef, GraphRef, dict[str, Any]]:
         path = self._normalize_user_path(path)
@@ -308,11 +465,55 @@ class _TablePlotMixin(_OriginClientBase):
 
         columns = [str(col) for col in df.columns]
         selected = self._resolve_selected_columns(columns, selected_cols)
+        style_mode_actual = self._normalize_style_mode(style_mode)
+        chart_type = self._nature_chart_type_for_plot_id(plot_type_id, template)
+        profile_x, profile_y, series_count = self._plot_type_visual_profile(
+            df,
+            selected,
+            plot_type_id,
+        )
+        axis_x_name, axis_y_names = self._plot_type_axis_fields(selected, plot_type_id)
+        smart_defaults = resolve_visual_defaults(
+            chart_type=chart_type,
+            series_count=series_count,
+            row_count=len(df),
+            x_values=profile_x,
+            y_series=profile_y,
+            show_legend=show_legend,
+            palette_name=palette_name,
+            style_mode=style_mode_actual,
+            x_name=axis_x_name,
+            y_names=axis_y_names,
+            table=df,
+            title_hint=title,
+            x_label=x_label,
+            y_label=y_label,
+        )
+        show_legend_actual = bool(decision_value(smart_defaults, "legend", "show"))
+        resolved_bin_width = histogram_bin_width
+        if histogram_bin_width == "auto":
+            resolved_bin_width = automatic_histogram_bin_width(df[selected[0]].to_numpy())
+        if resolved_bin_width is not None and (
+            not isinstance(resolved_bin_width, (int, float)) or resolved_bin_width <= 0
+        ):
+            raise OriginOperationError(
+                "histogram_bin_width must be a positive number or 'auto'."
+            )
         actual_book_name = book_name or (
             self._safe_filename(f"{graph_name}_Data") if graph_name else None
         )
         wks = self._new_sheet(book_name=actual_book_name, sheet_name=sheet_name)
         wks.from_df(df)
+        series_labels = decision_value(smart_defaults, "legend", "series_labels")
+        self._set_worksheet_display_labels(
+            wks,
+            columns,
+            overrides={
+                name: label
+                for name, label in zip(axis_y_names, series_labels, strict=True)
+                if name in columns
+            },
+        )
         if plot_type_id == 242:
             # Plot type 242 (3D Colormap Surface) consumes a matrix, not scattered
             # XYZ worksheet columns: plotxyz against XYZ produces an empty graph.
@@ -327,7 +528,9 @@ class _TablePlotMixin(_OriginClientBase):
                 x_label=x_label,
                 y_label=y_label,
                 style_mode=style_mode,
-                palette_name=palette_name,
+                palette_name=decision_value(smart_defaults, "palette_name"),
+                show_legend=show_legend_actual,
+                smart_defaults=smart_defaults,
                 export_path=export_path,
             )
         command, range_option = self._table_plot_command_options(plot_type_id)
@@ -340,20 +543,35 @@ class _TablePlotMixin(_OriginClientBase):
         reuse_existing_graph = existing_graph is not None and command != "worksheet"
         if reuse_existing_graph:
             self._clear_graph_plots(existing_graph, graph_name_actual)
-        if command == "worksheet":
-            script = self._worksheet_plot_command(columns, selected, plot_type_id, template)
-            result = self._execute_on_worksheet(wks, script)
-        else:
-            script = self._plot_command(
-                command=command,
-                range_option=range_option,
-                data_range=data_range,
-                plot_type_id=plot_type_id,
-                template=template,
-                graph_name=graph_name_actual,
-                reuse_existing=reuse_existing_graph,
-            )
-            result = self.run_labtalk(script)
+        creation_bin_width = (
+            float(resolved_bin_width)
+            if plot_type_id == 219 and resolved_bin_width is not None
+            else None
+        )
+        if creation_bin_width is not None:
+            # Origin calculates the derived Bin worksheet when the histogram is
+            # created. Setting @HBS beforehand gives the graph the correct bin
+            # counts and initial Y scale; changing -hbs afterward alone does not
+            # reliably rebuild those derived values in all Origin versions.
+            self.run_labtalk(f"@HBS={creation_bin_width:g};")
+        try:
+            if command == "worksheet":
+                script = self._worksheet_plot_command(columns, selected, plot_type_id, template)
+                result = self._execute_on_worksheet(wks, script)
+            else:
+                script = self._plot_command(
+                    command=command,
+                    range_option=range_option,
+                    data_range=data_range,
+                    plot_type_id=plot_type_id,
+                    template=template,
+                    graph_name=graph_name_actual,
+                    reuse_existing=reuse_existing_graph,
+                )
+                result = self.run_labtalk(script)
+        finally:
+            if creation_bin_width is not None:
+                self.run_labtalk("@HBS=-1;")
         self._assert_plot_type_command(
             plot_type_id=plot_type_id,
             template=template,
@@ -380,27 +598,59 @@ class _TablePlotMixin(_OriginClientBase):
             actual_graph_name=graph_name_actual,
         )
         self._remember_graph_alias(graph_name, graph_name_actual)
-        if title or x_label or y_label:
+        inferred_x_label = (
+            decision_value(smart_defaults, "axes", "x_title") if axis_x_name else None
+        )
+        inferred_y_label = (
+            decision_value(smart_defaults, "axes", "y_title") if axis_y_names else None
+        )
+        if title or inferred_x_label or inferred_y_label:
             try:
                 self.format_graph(
                     graph_name=graph_name_actual,
                     title=title,
-                    x_label=x_label,
-                    y_label=y_label,
+                    x_label=inferred_x_label,
+                    y_label=inferred_y_label,
                     rescale=True,
                 )
-            except OriginOperationError:
+            except OriginMcpError:
                 pass
         self._suppress_graph_title_text(graph_name=graph_name_actual, title=title)
-        style_mode_actual = self._normalize_style_mode(style_mode)
         if style_mode_actual == "nature":
             style_kwargs = {
                 "graph_name": graph_name_actual,
-                "chart_type": self._nature_chart_type_for_plot_id(plot_type_id, template),
+                "chart_type": chart_type,
+                "show_legend": show_legend_actual,
+                "palette_name": decision_value(smart_defaults, "palette_name"),
             }
-            if palette_name is not None:
-                style_kwargs["palette_name"] = palette_name
             self.apply_nature_style(**style_kwargs)
+        visual_defaults: dict[str, Any] = {"smart": smart_defaults}
+        if colormap is not None:
+            visual_defaults["colormap"] = self.set_plot_style(
+                graph_name=graph_name_actual,
+                colormap=colormap,
+            )
+        if resolved_bin_width is not None:
+            visual_defaults["histogram_bin_width"] = self.set_plot_style(
+                graph_name=graph_name_actual,
+                histogram_bin_width=float(resolved_bin_width),
+            )
+            # The plot is initially scaled for Origin's automatic bins. A
+            # custom width changes the counts and therefore requires a second
+            # rescale before export.
+            self.format_graph(graph_name=graph_name_actual, rescale=True)
+        try:
+            self.format_graph(
+                graph_name=graph_name_actual,
+                show_legend=show_legend_actual,
+                rescale=False,
+            )
+        except OriginMcpError:
+            pass
+        smart_defaults["applied"] = self._apply_smart_visual_defaults(
+            graph_name=graph_name_actual,
+            defaults=smart_defaults,
+        )
         exported = None
         if export_path is not None:
             exported = self._export_plot_command_graph(export_path, graph_name_actual)["path"]
@@ -417,6 +667,7 @@ class _TablePlotMixin(_OriginClientBase):
                     graph_name_actual,
                     default=title or graph_name,
                 ),
+                visual_defaults=smart_defaults,
             ),
             {
                 "script": script,
@@ -427,6 +678,7 @@ class _TablePlotMixin(_OriginClientBase):
                 "command": command,
                 "range_option": range_option,
                 "warning": output_warning,
+                "visual_defaults": visual_defaults,
             },
         )
 
@@ -443,6 +695,8 @@ class _TablePlotMixin(_OriginClientBase):
         y_label: str | None,
         style_mode: str,
         palette_name: str | None,
+        show_legend: bool,
+        smart_defaults: dict[str, Any],
         export_path: Path | None,
     ) -> tuple[WorksheetRef, GraphRef, dict[str, Any]]:
         """Grid scattered XYZ worksheet data into a matrix and plot a 3D
@@ -490,10 +744,22 @@ class _TablePlotMixin(_OriginClientBase):
             style_kwargs: dict[str, Any] = {
                 "graph_name": graph_name_actual,
                 "chart_type": self._nature_chart_type_for_plot_id(242, "glmesh"),
+                "show_legend": show_legend,
+                "palette_name": palette_name,
             }
-            if palette_name is not None:
-                style_kwargs["palette_name"] = palette_name
             self.apply_nature_style(**style_kwargs)
+        try:
+            self.format_graph(
+                graph_name=graph_name_actual,
+                show_legend=show_legend,
+                rescale=False,
+            )
+        except OriginMcpError:
+            pass
+        smart_defaults["applied"] = self._apply_smart_visual_defaults(
+            graph_name=graph_name_actual,
+            defaults=smart_defaults,
+        )
         exported = None
         if export_path is not None:
             exported = self._export_plot_command_graph(export_path, graph_name_actual)["path"]
@@ -510,6 +776,7 @@ class _TablePlotMixin(_OriginClientBase):
                     graph_name_actual,
                     default=title or graph_name,
                 ),
+                visual_defaults=smart_defaults,
             ),
             {
                 "script": script,
@@ -521,6 +788,7 @@ class _TablePlotMixin(_OriginClientBase):
                 "range_option": "im",
                 "data_range": data_range,
                 "warning": output_warning,
+                "visual_defaults": {"smart": smart_defaults},
             },
         )
 
@@ -813,6 +1081,173 @@ class _TablePlotMixin(_OriginClientBase):
             if graph_name:
                 self._set_page_long_name(graph, graph_name)
             return graph
+
+    @staticmethod
+    def _plot_type_visual_profile(
+        df: Any,
+        selected: list[str],
+        plot_type_id: int,
+    ) -> tuple[Any, list[Any], int]:
+        """Return X values, value series, and visual series count for a Plot ID."""
+
+        if plot_type_id == 219:
+            values = df[selected[0]].to_numpy()
+            return values, [values], 1
+        if plot_type_id == 206:
+            return selected, [df[name].to_numpy() for name in selected], len(selected)
+        single_mark_ids = {
+            183,
+            184,
+            185,
+            186,
+            191,
+            193,
+            208,
+            218,
+            221,
+            240,
+            242,
+            243,
+            245,
+            247,
+            248,
+        }
+        if plot_type_id in single_mark_ids:
+            return df[selected[0]].to_numpy(), [df[selected[-1]].to_numpy()], 1
+        value_names = selected[1:] or selected
+        return (
+            df[selected[0]].to_numpy(),
+            [df[name].to_numpy() for name in value_names],
+            max(1, len(value_names)),
+        )
+
+    @staticmethod
+    def _plot_type_axis_fields(
+        selected: list[str],
+        plot_type_id: int,
+    ) -> tuple[str | None, list[str]]:
+        """Return semantic X/Y fields for safe automatic axis titles."""
+
+        if plot_type_id == 219:
+            return selected[0], ["count"]
+        if plot_type_id == 206:
+            return "category", selected
+        no_simple_xy_axes = {103, 183, 184, 185, 186, 191, 225, 240, 242, 243, 245}
+        if plot_type_id in no_simple_xy_axes:
+            return None, []
+        if plot_type_id == 221:
+            return selected[0], selected[1:]
+        if plot_type_id in {193, 208, 218, 247, 248}:
+            return selected[0], [selected[1] if len(selected) > 1 else selected[0]]
+        return selected[0], selected[1:] or selected
+
+    def _apply_smart_visual_defaults(
+        self,
+        *,
+        graph_name: str,
+        defaults: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Apply resolved low-risk cross-chart rules to an Origin graph."""
+
+        safe_graph = self._escape_labtalk(graph_name)
+        rotation = int(decision_value(defaults, "axes", "x_tick_rotation") or 0)
+        number_format = decision_value(defaults, "axes", "y_number_format")
+        decimal_places = int(decision_value(defaults, "axes", "y_decimal_places"))
+        zero_baseline = bool(decision_value(defaults, "axes", "y_zero_baseline"))
+        canvas = defaults.get("canvas", {})
+        page_aspect_ratio = (
+            decision_value(canvas, "page_aspect_ratio")
+            if "page_aspect_ratio" in canvas
+            else None
+        )
+        bottom_margin = (
+            decision_value(canvas, "bottom_margin") if "bottom_margin" in canvas else None
+        )
+        page_width_aspect_ratio = (
+            decision_value(canvas, "page_width_aspect_ratio")
+            if "page_width_aspect_ratio" in canvas
+            else None
+        )
+        right_margin = (
+            decision_value(canvas, "right_margin") if "right_margin" in canvas else None
+        )
+        script_parts = [
+            f'win -a "{safe_graph}";',
+            "layer -s 1;",
+            f"layer.x.label.rotate={rotation};",
+            f"layer.y.label.numFormat={2 if number_format == 'scientific' else 1};",
+            f"layer.y.label.decPlaces={decimal_places};",
+        ]
+        if zero_baseline:
+            script_parts.append("layer.y.from=0;")
+        if page_aspect_ratio is not None or page_width_aspect_ratio is not None:
+            script_parts.append("page.kar=0;")
+            if page_aspect_ratio is not None:
+                script_parts.append(
+                    f"page.height=page.width/{float(page_aspect_ratio):g};"
+                )
+            elif page_width_aspect_ratio is not None:
+                script_parts.append(
+                    f"page.width=page.height*{float(page_width_aspect_ratio):g};"
+                )
+        if bottom_margin is not None or right_margin is not None:
+            script_parts.append(
+                "page -fls -u -ml 0.08 -mt 0.05 "
+                f"-mr {float(right_margin if right_margin is not None else 0.05):g} "
+                f"-mb {float(bottom_margin if bottom_margin is not None else 0.08):g};"
+            )
+        axis_script = " ".join(script_parts)
+        try:
+            axis_result = self.run_labtalk(axis_script)
+        except OriginMcpError as exc:
+            axis_result = {"warning": str(exc)}
+
+        mark_result = None
+        symbol_size = decision_value(defaults, "marks", "symbol_size")
+        transparency = decision_value(defaults, "marks", "transparency")
+        if symbol_size is not None or transparency is not None:
+            try:
+                mark_result = self.set_plot_style(
+                    graph_name=graph_name,
+                    symbol_size=symbol_size,
+                    transparency=transparency,
+                )
+            except OriginMcpError as exc:
+                mark_result = {"warning": str(exc)}
+
+        legend_result = None
+        if decision_value(defaults, "legend", "show"):
+            position = decision_value(defaults, "legend", "position")
+            if position is not None:
+                try:
+                    legend_result = self.format_legend(
+                        graph_name=graph_name,
+                        show_frame=False,
+                        position=position,
+                    )
+                except OriginMcpError as exc:
+                    legend_result = {"warning": str(exc), "position": position}
+        return {
+            "axis_script": axis_script,
+            "axis_result": axis_result,
+            "marks": mark_result,
+            "legend": legend_result,
+        }
+
+    @staticmethod
+    def _set_worksheet_display_labels(
+        wks: Any,
+        columns: list[str],
+        overrides: dict[str, str] | None = None,
+    ) -> None:
+        setter = getattr(wks, "set_labels", None)
+        if callable(setter):
+            labels = overrides or {}
+            setter(
+                [labels.get(column, humanize_field_name(column)) for column in columns],
+                "L",
+                offset=0,
+            )
 
     @staticmethod
     def _default_graph_templates() -> dict[str, str]:

--- a/src/origin_mcp/client/table_plot.py
+++ b/src/origin_mcp/client/table_plot.py
@@ -144,9 +144,7 @@ class _TablePlotMixin(_OriginClientBase):
             x_label=x_label,
             y_label=y_label,
         )
-        show_legend_actual = bool(
-            decision_value(visual_defaults, "legend", "show")
-        )
+        show_legend_actual = bool(decision_value(visual_defaults, "legend", "show"))
         graph_template = self._resolve_graph_template(kind=kind, template=template)
         graph = self._new_graph(kind=kind, graph_name=graph_name, template=graph_template)
         layer = graph[0] if hasattr(graph, "__getitem__") else graph
@@ -198,9 +196,7 @@ class _TablePlotMixin(_OriginClientBase):
             self.apply_nature_style(**style_kwargs)
         if kind == "histogram":
             resolved_bin_width = histogram_bin_width
-            if histogram_bin_width == "auto" or (
-                histogram_bin_width is None and template is None
-            ):
+            if histogram_bin_width == "auto" or (histogram_bin_width is None and template is None):
                 resolved_bin_width = automatic_histogram_bin_width(df[y_names[0]].to_numpy())
             if resolved_bin_width is not None:
                 if not isinstance(resolved_bin_width, (int, float)) or resolved_bin_width <= 0:
@@ -496,9 +492,7 @@ class _TablePlotMixin(_OriginClientBase):
         if resolved_bin_width is not None and (
             not isinstance(resolved_bin_width, (int, float)) or resolved_bin_width <= 0
         ):
-            raise OriginOperationError(
-                "histogram_bin_width must be a positive number or 'auto'."
-            )
+            raise OriginOperationError("histogram_bin_width must be a positive number or 'auto'.")
         actual_book_name = book_name or (
             self._safe_filename(f"{graph_name}_Data") if graph_name else None
         )
@@ -1156,9 +1150,7 @@ class _TablePlotMixin(_OriginClientBase):
         zero_baseline = bool(decision_value(defaults, "axes", "y_zero_baseline"))
         canvas = defaults.get("canvas", {})
         page_aspect_ratio = (
-            decision_value(canvas, "page_aspect_ratio")
-            if "page_aspect_ratio" in canvas
-            else None
+            decision_value(canvas, "page_aspect_ratio") if "page_aspect_ratio" in canvas else None
         )
         bottom_margin = (
             decision_value(canvas, "bottom_margin") if "bottom_margin" in canvas else None
@@ -1168,9 +1160,7 @@ class _TablePlotMixin(_OriginClientBase):
             if "page_width_aspect_ratio" in canvas
             else None
         )
-        right_margin = (
-            decision_value(canvas, "right_margin") if "right_margin" in canvas else None
-        )
+        right_margin = decision_value(canvas, "right_margin") if "right_margin" in canvas else None
         script_parts = [
             f'win -a "{safe_graph}";',
             "layer -s 1;",
@@ -1183,13 +1173,9 @@ class _TablePlotMixin(_OriginClientBase):
         if page_aspect_ratio is not None or page_width_aspect_ratio is not None:
             script_parts.append("page.kar=0;")
             if page_aspect_ratio is not None:
-                script_parts.append(
-                    f"page.height=page.width/{float(page_aspect_ratio):g};"
-                )
+                script_parts.append(f"page.height=page.width/{float(page_aspect_ratio):g};")
             elif page_width_aspect_ratio is not None:
-                script_parts.append(
-                    f"page.width=page.height*{float(page_width_aspect_ratio):g};"
-                )
+                script_parts.append(f"page.width=page.height*{float(page_width_aspect_ratio):g};")
         if bottom_margin is not None or right_margin is not None:
             script_parts.append(
                 "page -fls -u -ml 0.08 -mt 0.05 "

--- a/src/origin_mcp/models.py
+++ b/src/origin_mcp/models.py
@@ -125,7 +125,19 @@ class PlotTableRequest(TableImportRequest):
     title: str | None = Field(default=None, description="Optional graph page long name.")
     x_label: str | None = Field(default=None, description="Optional X axis title.")
     y_label: str | None = Field(default=None, description="Optional Y axis title.")
-    show_legend: bool = Field(default=True, description="Whether to refresh/show the graph legend.")
+    show_legend: bool | None = Field(
+        default=None,
+        description=(
+            "Legend visibility override. When omitted, cross-chart rules hide redundant "
+            "single-series legends and retain legends needed for multiple series."
+        ),
+    )
+    palette_name: str | None = Field(
+        default=None,
+        description=(
+            "Optional registered built-in palette name; nature mode selects one automatically."
+        ),
+    )
     style_mode: PlotStyleMode = Field(
         default=PlotStyleMode.origin_default,
         description=(

--- a/src/origin_mcp/refs.py
+++ b/src/origin_mcp/refs.py
@@ -31,7 +31,7 @@ class GraphRef:
     visual_defaults: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        data = {
+        data: dict[str, Any] = {
             "graph_name": self.graph_name,
             "export_path": self.export_path,
             "template": self.template,

--- a/src/origin_mcp/refs.py
+++ b/src/origin_mcp/refs.py
@@ -28,6 +28,7 @@ class GraphRef:
     style_mode: str = "origin_default"
     requested_graph_name: str | None = None
     display_name: str | None = None
+    visual_defaults: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         data = {
@@ -40,4 +41,6 @@ class GraphRef:
             data["requested_graph_name"] = self.requested_graph_name
         if self.display_name is not None:
             data["display_name"] = self.display_name
+        if self.visual_defaults is not None:
+            data["visual_defaults"] = self.visual_defaults
         return data

--- a/src/origin_mcp/text_format.py
+++ b/src/origin_mcp/text_format.py
@@ -361,12 +361,14 @@ def infer_series_labels(
         SERIES_CONTAINER_TOKENS | SERIES_DIMENSION_TOKENS | GENERIC_VALUE_TOKENS
     ):
         if omit_units_when_metrics_differ:
-            labels = [
+            candidate_labels = [
                 origin_rich_text(_format_field_words([*item.metric_tokens, *item.statistic_roles]))
                 for item in parsed
             ]
-            if all(labels) and len({label.casefold() for label in labels}) == len(labels):
-                return labels
+            if all(candidate_labels) and len(
+                {label.casefold() for label in candidate_labels}
+            ) == len(candidate_labels):
+                return candidate_labels
         return [humanize_field_name(item.raw) for item in parsed]
 
     labels: list[str] = []

--- a/src/origin_mcp/text_format.py
+++ b/src/origin_mcp/text_format.py
@@ -60,9 +60,7 @@ FIELD_UNIT_SUFFIXES = {
     "percent": "%",
 }
 
-FIELD_UNIT_TOKEN_SUFFIXES = {
-    (token,): unit for token, unit in FIELD_UNIT_SUFFIXES.items()
-} | {
+FIELD_UNIT_TOKEN_SUFFIXES = {(token,): unit for token, unit in FIELD_UNIT_SUFFIXES.items()} | {
     ("mg", "dL"): "mg/dL",
     ("mg", "L"): "mg/L",
     ("g", "L"): "g/L",
@@ -141,6 +139,7 @@ class AxisTitleInference:
     unit: str | None
     reason: str
     source: str = "smart_default"
+
 
 SUPERSCRIPT_CHARS = {
     "⁰": "0",
@@ -312,8 +311,7 @@ def infer_axis_title(
     shared_unit = units[0] if all(unit == units[0] for unit in units) else None
     common_metric = _common_metric_tokens(parsed)
     generic_fields = all(
-        not item.metric_tokens
-        or set(item.metric_tokens).issubset(GENERIC_VALUE_TOKENS)
+        not item.metric_tokens or set(item.metric_tokens).issubset(GENERIC_VALUE_TOKENS)
         for item in parsed
     )
     table_metric = _constant_table_value(table, TABLE_METRIC_COLUMNS) if generic_fields else None
@@ -364,9 +362,7 @@ def infer_series_labels(
     ):
         if omit_units_when_metrics_differ:
             labels = [
-                origin_rich_text(
-                    _format_field_words([*item.metric_tokens, *item.statistic_roles])
-                )
+                origin_rich_text(_format_field_words([*item.metric_tokens, *item.statistic_roles]))
                 for item in parsed
             ]
             if all(labels) and len({label.casefold() for label in labels}) == len(labels):

--- a/src/origin_mcp/text_format.py
+++ b/src/origin_mcp/text_format.py
@@ -1,8 +1,146 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from typing import Any
 
-ORIGIN_ESCAPE_MARKERS = ("\\+(", "\\-(", "\\=(")
+ORIGIN_UNICODE_ESCAPES = {
+    "µ": r"\x(00B5)",
+    "μ": r"\x(00B5)",
+    "°": r"\x(00B0)",
+    "Ω": r"\x(03A9)",
+    "Å": r"\x(00C5)",
+    "×": r"\x(00D7)",
+    "−": r"\x(2212)",
+}
+
+FIELD_WORD_ALIASES = {
+    "api": "API",
+    "cpu": "CPU",
+    "gpu": "GPU",
+    "id": "ID",
+    "mcp": "MCP",
+    "rms": "RMS",
+    "sd": "SD",
+    "sem": "SEM",
+    "url": "URL",
+}
+
+FIELD_UNIT_SUFFIXES = {
+    "s": "s",
+    "ms": "ms",
+    "us": "µs",
+    "µs": "µs",
+    "μs": "µs",
+    "ns": "ns",
+    "um": "µm",
+    "µm": "µm",
+    "μm": "µm",
+    "nm": "nm",
+    "uM": "µM",
+    "µM": "µM",
+    "μM": "µM",
+    "Hz": "Hz",
+    "kHz": "kHz",
+    "MHz": "MHz",
+    "GHz": "GHz",
+    "degC": "°C",
+    "C": "°C",
+    "K": "K",
+    "Pa": "Pa",
+    "kPa": "kPa",
+    "MPa": "MPa",
+    "V": "V",
+    "mV": "mV",
+    "A": "A",
+    "mA": "mA",
+    "W": "W",
+    "kW": "kW",
+    "pct": "%",
+    "percent": "%",
+}
+
+FIELD_UNIT_TOKEN_SUFFIXES = {
+    (token,): unit for token, unit in FIELD_UNIT_SUFFIXES.items()
+} | {
+    ("mg", "dL"): "mg/dL",
+    ("mg", "L"): "mg/L",
+    ("g", "L"): "g/L",
+    ("kg", "m3"): "kg/m³",
+    ("m", "s"): "m/s",
+}
+
+STAT_ROLE_ALIASES = {
+    "mean": "Mean",
+    "avg": "Mean",
+    "average": "Mean",
+    "median": "Median",
+    "std": "SD",
+    "sd": "SD",
+    "stdev": "SD",
+    "sem": "SEM",
+    "stderr": "SEM",
+    "min": "Minimum",
+    "max": "Maximum",
+    "lower": "Lower",
+    "upper": "Upper",
+}
+
+GENERIC_VALUE_TOKENS = {"value", "values", "measurement", "measure", "result"}
+SERIES_CONTAINER_TOKENS = {
+    "channel",
+    "compound",
+    "condition",
+    "group",
+    "replicate",
+    "sample",
+    "sensor",
+    "series",
+    "treatment",
+}
+SERIES_DIMENSION_TOKENS = {
+    "baseline",
+    "control",
+    "placebo",
+    "reference",
+    "treated",
+    "treatment",
+}
+TITLE_STOP_TOKENS = {
+    "across",
+    "and",
+    "by",
+    "chart",
+    "comparison",
+    "distribution",
+    "figure",
+    "over",
+    "plot",
+    "relationship",
+    "trend",
+    "versus",
+    "vs",
+}
+TABLE_METRIC_COLUMNS = {"measure", "measurement", "metric", "parameter", "variable"}
+TABLE_UNIT_COLUMNS = {"measurement_unit", "unit", "units"}
+
+
+@dataclass(frozen=True)
+class FieldSemantics:
+    raw: str
+    tokens: tuple[str, ...]
+    metric_tokens: tuple[str, ...]
+    statistic_roles: tuple[str, ...]
+    unit: str | None
+
+
+@dataclass(frozen=True)
+class AxisTitleInference:
+    label: str
+    metric: str
+    unit: str | None
+    reason: str
+    source: str = "smart_default"
 
 SUPERSCRIPT_CHARS = {
     "⁰": "0",
@@ -73,10 +211,9 @@ SINGLE_LETTER_SUB_PATTERN = re.compile(r"_(?!\{)([A-Za-z])(?![A-Za-z0-9_])")
 def origin_rich_text(text: str) -> str:
     """Convert common subscript/superscript notation to Origin escape sequences."""
 
-    if any(marker in text for marker in ORIGIN_ESCAPE_MARKERS):
-        return normalize_label_text(text)
-
     formatted = normalize_label_text(text)
+    for character, escape in ORIGIN_UNICODE_ESCAPES.items():
+        formatted = formatted.replace(character, escape)
     formatted = HTML_SUB_PATTERN.sub(lambda match: _origin_sub(match.group(1)), formatted)
     formatted = HTML_SUP_PATTERN.sub(lambda match: _origin_super(match.group(1)), formatted)
     formatted = BRACED_SUB_PATTERN.sub(lambda match: _origin_sub(match.group(1)), formatted)
@@ -93,6 +230,252 @@ def origin_rich_text(text: str) -> str:
         formatted,
     )
     return formatted
+
+
+def humanize_field_name(name: str) -> str:
+    """Turn a machine-oriented field name into an Origin-ready display label."""
+
+    value = normalize_label_text(str(name)).strip()
+    if not value:
+        return value
+    if " " in value or "(" in value or ")" in value:
+        return origin_rich_text(value)
+
+    tokens = _split_field_tokens(value)
+    if not tokens:
+        return origin_rich_text(value)
+    tokens, unit = _extract_field_unit(tokens)
+
+    words = [FIELD_WORD_ALIASES.get(token.lower(), token.lower()) for token in tokens]
+    if words:
+        first = words[0]
+        words[0] = first if first.isupper() else first[:1].upper() + first[1:]
+    label = " ".join(words) or value
+    if unit is not None:
+        label = f"{label} ({unit})"
+    return origin_rich_text(label)
+
+
+def parse_field_semantics(name: str) -> FieldSemantics:
+    """Split a field into metric words, statistical roles, and a unit."""
+
+    raw = normalize_label_text(str(name)).strip()
+    tokens, unit = _extract_field_unit(_split_field_tokens(raw))
+    metric_tokens: list[str] = []
+    statistic_roles: list[str] = []
+    for token in tokens:
+        role = STAT_ROLE_ALIASES.get(token.lower())
+        if role is None:
+            metric_tokens.append(token.lower())
+        elif role not in statistic_roles:
+            statistic_roles.append(role)
+    return FieldSemantics(
+        raw=raw,
+        tokens=tuple(tokens),
+        metric_tokens=tuple(metric_tokens),
+        statistic_roles=tuple(statistic_roles),
+        unit=unit,
+    )
+
+
+def infer_axis_title(
+    field_names: list[str] | tuple[str, ...],
+    *,
+    explicit: str | None = None,
+    table: Any = None,
+    title_hint: str | None = None,
+    x_name: str | None = None,
+    fallback: str = "Value",
+) -> AxisTitleInference:
+    """Infer one concise axis title from one or more data fields."""
+
+    if explicit is not None:
+        label = origin_rich_text(explicit)
+        return AxisTitleInference(
+            label=label,
+            metric=explicit,
+            unit=None,
+            reason="explicit_user_value",
+            source="user",
+        )
+
+    parsed = [parse_field_semantics(name) for name in field_names if str(name).strip()]
+    if not parsed:
+        return AxisTitleInference(
+            label=origin_rich_text(fallback),
+            metric=fallback,
+            unit=None,
+            reason="generic_value_fallback",
+        )
+
+    units = [item.unit for item in parsed]
+    shared_unit = units[0] if all(unit == units[0] for unit in units) else None
+    common_metric = _common_metric_tokens(parsed)
+    generic_fields = all(
+        not item.metric_tokens
+        or set(item.metric_tokens).issubset(GENERIC_VALUE_TOKENS)
+        for item in parsed
+    )
+    table_metric = _constant_table_value(table, TABLE_METRIC_COLUMNS) if generic_fields else None
+    table_unit = _constant_table_value(table, TABLE_UNIT_COLUMNS) if generic_fields else None
+    if table_metric:
+        common_metric = tuple(_split_field_tokens(table_metric))
+    if table_unit:
+        shared_unit = _normalize_unit_value(table_unit)
+
+    reason = "shared_metric_and_unit" if len(parsed) > 1 else "field_semantics"
+    if table_metric or table_unit:
+        reason = "table_metric_unit_columns"
+    if not common_metric or set(common_metric).issubset(
+        GENERIC_VALUE_TOKENS | SERIES_CONTAINER_TOKENS | SERIES_DIMENSION_TOKENS
+    ):
+        common_metric = _title_metric_tokens(title_hint, x_name)
+        if common_metric:
+            reason = "chart_title_context"
+    if not common_metric:
+        common_metric = tuple(_split_field_tokens(fallback))
+        reason = "generic_value_fallback"
+    if len(set(units)) > 1 and any(unit is not None for unit in units):
+        reason = "mixed_units_metric_only"
+
+    metric = _format_field_words(list(common_metric)) or fallback
+    label = f"{metric} ({shared_unit})" if shared_unit else metric
+    return AxisTitleInference(
+        label=origin_rich_text(label),
+        metric=metric,
+        unit=shared_unit,
+        reason=reason,
+    )
+
+
+def infer_series_labels(
+    field_names: list[str] | tuple[str, ...],
+    *,
+    omit_units_when_metrics_differ: bool = False,
+) -> list[str]:
+    """Return legend labels that omit metric/unit text already carried by an axis."""
+
+    parsed = [parse_field_semantics(name) for name in field_names]
+    if len(parsed) <= 1:
+        return [humanize_field_name(item.raw) for item in parsed]
+    common_metric = _common_metric_tokens(parsed)
+    if not common_metric or set(common_metric).issubset(
+        SERIES_CONTAINER_TOKENS | SERIES_DIMENSION_TOKENS | GENERIC_VALUE_TOKENS
+    ):
+        if omit_units_when_metrics_differ:
+            labels = [
+                origin_rich_text(
+                    _format_field_words([*item.metric_tokens, *item.statistic_roles])
+                )
+                for item in parsed
+            ]
+            if all(labels) and len({label.casefold() for label in labels}) == len(labels):
+                return labels
+        return [humanize_field_name(item.raw) for item in parsed]
+
+    labels: list[str] = []
+    for item in parsed:
+        residual = _subtract_tokens(item.metric_tokens, common_metric)
+        label_tokens = [*residual, *item.statistic_roles]
+        if not label_tokens:
+            labels.append(humanize_field_name(item.raw))
+            continue
+        labels.append(origin_rich_text(_format_field_words(label_tokens)))
+    if len({label.casefold() for label in labels}) != len(labels):
+        return [humanize_field_name(item.raw) for item in parsed]
+    return labels
+
+
+def _split_field_tokens(value: str) -> list[str]:
+    return [token for token in re.split(r"[_\-\s]+", value) if token]
+
+
+def _extract_field_unit(tokens: list[str]) -> tuple[list[str], str | None]:
+    for suffix, unit in sorted(
+        FIELD_UNIT_TOKEN_SUFFIXES.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    ):
+        length = len(suffix)
+        if len(tokens) > length and tuple(tokens[-length:]) == suffix:
+            return tokens[:-length], unit
+    return tokens, None
+
+
+def _common_metric_tokens(parsed: list[FieldSemantics]) -> tuple[str, ...]:
+    if not parsed:
+        return ()
+    common = set(parsed[0].metric_tokens)
+    for item in parsed[1:]:
+        common.intersection_update(item.metric_tokens)
+    return tuple(token for token in parsed[0].metric_tokens if token in common)
+
+
+def _title_metric_tokens(title_hint: str | None, x_name: str | None) -> tuple[str, ...]:
+    if not title_hint:
+        return ()
+    x_tokens = set(parse_field_semantics(x_name).metric_tokens) if x_name else set()
+    candidates = [
+        token.lower()
+        for token in _split_field_tokens(title_hint)
+        if token.lower() not in TITLE_STOP_TOKENS and token.lower() not in x_tokens
+    ]
+    candidates = [
+        token
+        for token in candidates
+        if token not in SERIES_CONTAINER_TOKENS | SERIES_DIMENSION_TOKENS
+    ]
+    return tuple(candidates[-2:])
+
+
+def _constant_table_value(table: Any, aliases: set[str]) -> str | None:
+    columns = getattr(table, "columns", None)
+    if columns is None:
+        return None
+    for column in columns:
+        normalized = str(column).strip().lower().replace("-", "_").replace(" ", "_")
+        if normalized not in aliases:
+            continue
+        try:
+            values = table[column].dropna().astype(str).str.strip()
+            unique = [value for value in values.unique().tolist() if value]
+        except Exception:
+            continue
+        if len(unique) == 1:
+            return unique[0]
+    return None
+
+
+def _normalize_unit_value(value: str) -> str:
+    aliases = {
+        "C": "°C",
+        "degC": "°C",
+        "pct": "%",
+        "percent": "%",
+        "uM": "µM",
+        "μM": "µM",
+    }
+    return aliases.get(value.strip(), value.strip())
+
+
+def _format_field_words(tokens: list[str] | tuple[str, ...]) -> str:
+    words = [FIELD_WORD_ALIASES.get(token.lower(), token.lower()) for token in tokens]
+    if not words:
+        return ""
+    first = words[0]
+    words[0] = first if first.isupper() else first[:1].upper() + first[1:]
+    return " ".join(words)
+
+
+def _subtract_tokens(
+    tokens: tuple[str, ...],
+    removed: tuple[str, ...],
+) -> list[str]:
+    remaining = list(tokens)
+    for token in removed:
+        if token in remaining:
+            remaining.remove(token)
+    return remaining
 
 
 def normalize_label_text(text: str) -> str:

--- a/src/origin_mcp/tools/_shared.py
+++ b/src/origin_mcp/tools/_shared.py
@@ -330,7 +330,10 @@ _COMMON_PARAMETER_DESCRIPTIONS = {
     "selected_cols": "Column names or zero-based indexes to include in the plot.",
     "sheet_name": "Origin worksheet name. Omit to use the active sheet or the tool default.",
     "show": "Whether Origin should be visible after connecting or querying capabilities.",
-    "show_legend": "Whether the graph legend should be shown; null leaves it unchanged.",
+    "show_legend": (
+        "Legend visibility override; null uses cross-chart rules based on series count "
+        "and chart type."
+    ),
     "skiprows": "Zero-based input row index or indexes to skip while reading the file.",
     "spec": "Declarative FigureSpec describing data, layout, plots, style, export, and QA.",
     "start_col": "Column name or zero-based column index at which writing begins.",

--- a/src/origin_mcp/tools/figurespec.py
+++ b/src/origin_mcp/tools/figurespec.py
@@ -6,6 +6,7 @@ from typing import Any
 from origin_mcp.client.graph_style import NATURE_ANNOTATION_FONT_SIZE
 from origin_mcp.file_io import read_table
 from origin_mcp.models import FigureExportFormatSpec, FigureSpec
+from origin_mcp.visual_defaults import DEFAULT_HEATMAP_COLORMAP
 
 from ._shared import _mcp_tool, _ok, _wrap, client
 
@@ -382,8 +383,13 @@ def _create_base_graph(
             title=spec.figure.title or layer.title,
             x_label=layer.x.title,
             y_label=layer.y.title,
+            show_legend=_show_legend(spec),
             style_mode=_style_mode(spec),
             palette_name=spec.style.palette_name,
+            colormap=(
+                plot.style.get("colormap")
+                or (DEFAULT_HEATMAP_COLORMAP if spec.style.template is None else None)
+            ),
             export_path=None,
         )
         return worksheet, graph, command
@@ -464,6 +470,14 @@ def _create_base_graph(
         show_legend=_show_legend(spec),
         style_mode=_style_mode(spec),
         palette_name=spec.style.palette_name,
+        histogram_bin_width=(
+            plot.style.get(
+                "histogram_bin_width",
+                "auto" if spec.style.template is None else None,
+            )
+            if plot_type == "histogram"
+            else None
+        ),
         export_path=None,
     )
     return worksheet, graph, None
@@ -1077,7 +1091,12 @@ def _show_legend(spec: FigureSpec) -> bool:
     for item in spec.annotations:
         if item.type.strip().lower() == "legend":
             return True
-    return True
+    series_count = 0
+    for plot in spec.plots:
+        data = _data_by_id(spec, _plot_data_ref(spec, plot))
+        mapping = _plot_mapping(data, plot)
+        series_count += len(_y_columns(mapping) or [None])
+    return series_count > 1
 
 
 def _y_columns(mapping: dict[str, Any]) -> list[str | int] | None:

--- a/src/origin_mcp/tools/plotting_basic.py
+++ b/src/origin_mcp/tools/plotting_basic.py
@@ -30,8 +30,9 @@ def origin_plot_line(
     y_label: str | None = None,
     y_error_col: str | int | None = None,
     x_error_col: str | int | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a line graph."""
@@ -59,6 +60,7 @@ def origin_plot_line(
         x_error_col=x_error_col,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -84,8 +86,9 @@ def origin_plot_scatter(
     y_label: str | None = None,
     y_error_col: str | int | None = None,
     x_error_col: str | int | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a scatter graph."""
@@ -113,6 +116,7 @@ def origin_plot_scatter(
         x_error_col=x_error_col,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -138,8 +142,9 @@ def origin_plot_line_symbol(
     y_label: str | None = None,
     y_error_col: str | int | None = None,
     x_error_col: str | int | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a line+symbol graph."""
@@ -167,6 +172,7 @@ def origin_plot_line_symbol(
         x_error_col=x_error_col,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -192,8 +198,9 @@ def origin_plot_column(
     y_label: str | None = None,
     y_error_col: str | int | None = None,
     bar_gap: float | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a column/bar-style graph."""
@@ -221,6 +228,7 @@ def origin_plot_column(
         bar_gap=bar_gap,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -245,8 +253,9 @@ def origin_plot_contour(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import XYZ table data and create a contour graph."""
@@ -273,6 +282,7 @@ def origin_plot_contour(
         z_col=z_col,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -298,8 +308,9 @@ def origin_plot_errorbar(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a line+symbol plot with error bars."""
@@ -327,6 +338,7 @@ def origin_plot_errorbar(
         x_error_col=x_error_col,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -350,8 +362,10 @@ def origin_plot_histogram(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
+    bin_width: float | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a histogram graph."""
@@ -375,22 +389,17 @@ def origin_plot_histogram(
             title=title,
             x_label=x_label,
             y_label=y_label,
+            show_legend=show_legend,
             style_mode=style_mode,
+            palette_name=palette_name,
+            histogram_bin_width=(
+                bin_width if bin_width is not None else ("auto" if template is None else None)
+            ),
             export_path=export_path,
         )
-        _apply_plot_id_legend_visibility(result, show_legend)
         return result
 
     return run()
-
-
-def _apply_plot_id_legend_visibility(result: dict[str, Any], show_legend: bool) -> None:
-    if not result.get("ok"):
-        return
-    graph_data = result.get("data", {}).get("graph", {})
-    graph_name = graph_data.get("graph_name")
-    if graph_name:
-        client.format_graph(graph_name=graph_name, show_legend=show_legend, rescale=False)
 
 
 @_mcp_tool()
@@ -412,8 +421,9 @@ def origin_plot_box(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a box plot."""
@@ -436,10 +446,11 @@ def origin_plot_box(
         title=title,
         x_label=x_label,
         y_label=y_label,
+        show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
-    _apply_plot_id_legend_visibility(result, show_legend)
     return result
 
 
@@ -463,14 +474,15 @@ def origin_plot_heatmap(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
+    colormap: str | None = None,
     style_mode: str = "origin_default",
     palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import XYZ table data and create a heatmap graph."""
 
-    return _plot_table_id(
+    result = _plot_table_id(
         path=path,
         plot_type_id=243,
         template=template or "Contour",
@@ -488,10 +500,13 @@ def origin_plot_heatmap(
         title=title,
         x_label=x_label,
         y_label=y_label,
+        show_legend=show_legend,
         style_mode=style_mode,
         palette_name=palette_name,
+        colormap=colormap or ("viridis" if template is None else None),
         export_path=export_path,
     )
+    return result
 
 
 @_mcp_tool()
@@ -514,8 +529,9 @@ def origin_plot_3d_scatter(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import XYZ table data and create a 3D scatter graph."""
@@ -538,7 +554,9 @@ def origin_plot_3d_scatter(
         title=title,
         x_label=x_label,
         y_label=y_label,
+        show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -563,8 +581,9 @@ def origin_plot_3d_surface(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import XYZ table data and create a 3D surface graph."""
@@ -587,7 +606,9 @@ def origin_plot_3d_surface(
         title=title,
         x_label=x_label,
         y_label=y_label,
+        show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -611,8 +632,9 @@ def origin_plot_polar(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
-    show_legend: bool = True,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a polar graph."""
@@ -638,6 +660,7 @@ def origin_plot_polar(
         y_label=y_label,
         show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -661,6 +684,7 @@ def origin_plot_table_id(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
     palette_name: str | None = None,
     export_path: str | None = None,
@@ -685,7 +709,9 @@ def origin_plot_table_id(
         title=title,
         x_label=x_label,
         y_label=y_label,
+        show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -711,7 +737,9 @@ def origin_plot_dual_y(
     y1_label: str | None = None,
     y2_label: str | None = None,
     plot_type: str = "line",
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
+    palette_name: str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     """Import table data and create a double-Y (two Y axes) graph.
@@ -742,7 +770,9 @@ def origin_plot_dual_y(
             y1_label=y1_label,
             y2_label=y2_label,
             plot_type=plot_type,
+            show_legend=show_legend,
             style_mode=style_mode,
+            palette_name=palette_name,
             export_path=Path(export_path) if export_path else None,
         )
         return _ok(

--- a/src/origin_mcp/tools/plotting_plot_ids.py
+++ b/src/origin_mcp/tools/plotting_plot_ids.py
@@ -459,6 +459,8 @@ def _pti(
     title: str | None,
     export_path: str | None,
     style_mode: str = "origin_default",
+    show_legend: bool | None = None,
+    palette_name: str | None = None,
 ) -> dict[str, Any]:
     plot_type_id, template = PLOT_TYPE_ID_ROUTES[route]
     return _plot_table_id(
@@ -468,7 +470,9 @@ def _pti(
         selected_cols=selected_cols,
         graph_name=graph_name,
         title=title,
+        show_legend=show_legend,
         style_mode=style_mode,
+        palette_name=palette_name,
         export_path=export_path,
     )
 
@@ -498,6 +502,8 @@ def origin_plot(
     title: str | None = None,
     export_path: str | None = None,
     style_mode: str = "origin_default",
+    show_legend: bool | None = None,
+    palette_name: str | None = None,
 ) -> dict[str, Any]:
     """Create a table-based plot selected by ``kind``.
 
@@ -533,8 +539,9 @@ def origin_plot(
                 title=title,
                 x_label=None,
                 y_label=None,
-                show_legend=True,
+                show_legend=show_legend,
                 style_mode=style_mode,
+                palette_name=palette_name,
                 export_path=export_path,
             )
         if kind in _DISTRIBUTION_PLOT_KINDS:
@@ -546,7 +553,9 @@ def origin_plot(
                 selected_cols=selected_cols,
                 graph_name=graph_name,
                 title=title,
+                show_legend=show_legend,
                 style_mode=style_mode,
+                palette_name=palette_name,
                 export_path=export_path,
             )
         if kind not in PLOT_TYPE_ID_ROUTES:
@@ -558,7 +567,17 @@ def origin_plot(
                 )
             )
             raise ValueError(f"Unknown plot kind: {kind!r}. Valid kinds: {valid}.")
-        return _pti(path, kind, selected_cols, graph_name, title, export_path, style_mode)
+        return _pti(
+            path,
+            kind,
+            selected_cols,
+            graph_name,
+            title,
+            export_path,
+            style_mode,
+            show_legend,
+            palette_name,
+        )
 
     return _wrap(run)
 

--- a/src/origin_mcp/tools/plotting_shared.py
+++ b/src/origin_mcp/tools/plotting_shared.py
@@ -72,13 +72,14 @@ def _plot_csv(
     title: str | None,
     x_label: str | None,
     y_label: str | None,
-    show_legend: bool,
+    show_legend: bool | None,
     style_mode: str,
     export_path: str | None,
     z_col: str | int | None = None,
     y_error_col: str | int | None = None,
     x_error_col: str | int | None = None,
     bar_gap: float | None = None,
+    palette_name: str | None = None,
 ) -> dict[str, Any]:
     def run() -> dict[str, Any]:
         req = PlotTableRequest(
@@ -104,6 +105,7 @@ def _plot_csv(
             x_error_col=x_error_col,
             show_legend=show_legend,
             style_mode=PlotStyleMode(style_mode),
+            palette_name=palette_name,
             export_path=Path(export_path) if export_path else None,
         )
         worksheet, graph = client.plot_table(
@@ -130,6 +132,7 @@ def _plot_csv(
             x_error_col=req.x_error_col,
             show_legend=req.show_legend,
             style_mode=req.style_mode.value,
+            palette_name=req.palette_name,
             export_path=req.export_path,
         )
         if bar_gap is not None:
@@ -162,8 +165,11 @@ def _plot_table_id(
     title: str | None = None,
     x_label: str | None = None,
     y_label: str | None = None,
+    show_legend: bool | None = None,
     style_mode: str = "origin_default",
     palette_name: str | None = None,
+    colormap: str | None = None,
+    histogram_bin_width: float | str | None = None,
     export_path: str | None = None,
 ) -> dict[str, Any]:
     def run() -> dict[str, Any]:
@@ -186,8 +192,11 @@ def _plot_table_id(
             title=title,
             x_label=x_label,
             y_label=y_label,
+            show_legend=show_legend,
             style_mode=style_mode_actual,
             palette_name=palette_name,
+            colormap=colormap,
+            histogram_bin_width=histogram_bin_width,
             export_path=Path(export_path) if export_path else None,
         )
         return _ok(

--- a/src/origin_mcp/visual_defaults.py
+++ b/src/origin_mcp/visual_defaults.py
@@ -164,9 +164,7 @@ def resolve_visual_defaults(
         else None
     )
     y_format, y_decimals = _numeric_format(context.y_min, context.y_max)
-    zero_baseline = context.chart_type == "bar" and (
-        context.y_min is None or context.y_min >= 0
-    )
+    zero_baseline = context.chart_type == "bar" and (context.y_min is None or context.y_min >= 0)
 
     aspect_ratios = {
         "line": 1.5,
@@ -347,9 +345,7 @@ def _rotated_label_canvas(
             _decision(0.35, "reserve_space_for_vertical_category_labels"),
         )
     if rotation >= 45:
-        heavily_crowded = (
-            context.x_unique_count >= 12 or context.longest_x_label >= 18
-        )
+        heavily_crowded = context.x_unique_count >= 12 or context.longest_x_label >= 18
         if heavily_crowded:
             return (
                 _decision(1.05, "extra_page_height_for_long_rotated_category_labels"),
@@ -377,8 +373,10 @@ def _legend_layout_defaults(
     total = sum(lengths)
     fallback_outside = series_count >= 7 or longest > 24 or total > 90
     placement_assessed = bool(placement and placement["assessed"])
-    outside = visible and series_count > 1 and (
-        not placement["has_safe_inside"] if placement_assessed else fallback_outside
+    outside = (
+        visible
+        and series_count > 1
+        and (not placement["has_safe_inside"] if placement_assessed else fallback_outside)
     )
     occupancy_reason = (
         "all_inside_legend_regions_intersect_data"

--- a/src/origin_mcp/visual_defaults.py
+++ b/src/origin_mcp/visual_defaults.py
@@ -373,11 +373,11 @@ def _legend_layout_defaults(
     total = sum(lengths)
     fallback_outside = series_count >= 7 or longest > 24 or total > 90
     placement_assessed = bool(placement and placement["assessed"])
-    outside = (
-        visible
-        and series_count > 1
-        and (not placement["has_safe_inside"] if placement_assessed else fallback_outside)
-    )
+    if placement is not None and placement_assessed:
+        needs_outside = not placement["has_safe_inside"]
+    else:
+        needs_outside = fallback_outside
+    outside = visible and series_count > 1 and needs_outside
     occupancy_reason = (
         "all_inside_legend_regions_intersect_data"
         if placement_assessed

--- a/src/origin_mcp/visual_defaults.py
+++ b/src/origin_mcp/visual_defaults.py
@@ -1,0 +1,700 @@
+"""Pure helpers for readable, non-destructive plotting defaults.
+
+The resolver in this module deliberately has no Origin dependency.  Plotting
+code can therefore profile a table and explain every automatic visual choice
+before the corresponding Origin properties are applied.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from .chart_palette import normalize_chart_type
+from .text_format import humanize_field_name, infer_axis_title, infer_series_labels
+
+DEFAULT_HEATMAP_COLORMAP = "viridis"
+
+
+@dataclass(frozen=True)
+class VisualContext:
+    raw_chart_type: str
+    chart_type: str
+    series_count: int
+    row_count: int
+    x_is_categorical: bool
+    x_unique_count: int
+    longest_x_label: int
+    y_min: float | None
+    y_max: float | None
+
+
+def resolve_visual_defaults(
+    *,
+    chart_type: str,
+    series_count: int,
+    row_count: int,
+    x_values: Any = None,
+    y_series: list[Any] | None = None,
+    show_legend: bool | None = None,
+    palette_name: str | None = None,
+    style_mode: str = "origin_default",
+    x_name: str | None = None,
+    y_names: list[str] | None = None,
+    y2_names: list[str] | None = None,
+    table: Any = None,
+    title_hint: str | None = None,
+    x_label: str | None = None,
+    y_label: str | None = None,
+    y2_label: str | None = None,
+) -> dict[str, Any]:
+    """Resolve conservative cross-chart defaults and record their rationale.
+
+    Explicit caller values always win.  Palette automation is activated only
+    for the ``nature`` style so Origin/template styling remains untouched in
+    ``origin_default`` mode.
+    """
+
+    context = _visual_context(
+        chart_type=chart_type,
+        series_count=series_count,
+        row_count=row_count,
+        x_values=x_values,
+        y_series=y_series or [],
+    )
+
+    if show_legend is not None:
+        legend_visible = _decision(bool(show_legend), "explicit_user_value", "user")
+    elif context.series_count <= 1:
+        legend_visible = _decision(False, "single_series")
+    elif context.chart_type in {"heatmap", "surface"}:
+        legend_visible = _decision(False, "color_scale_carries_the_value_encoding")
+    elif context.chart_type == "box":
+        legend_visible = _decision(False, "category_axis_identifies_the_groups")
+    else:
+        legend_visible = _decision(True, "multiple_series_require_identification")
+
+    if palette_name is not None:
+        palette = _decision(palette_name, "explicit_user_value", "user")
+    elif style_mode == "nature":
+        palette = _decision(
+            "lcpmgh_auto",
+            "match_an_installed_lcpmgh_palette_to_the_series_count",
+        )
+    else:
+        palette = _decision(None, "preserve_origin_or_template_palette")
+
+    y_names_actual = list(y_names or [])
+    y2_names_actual = list(y2_names or [])
+    all_series_names = [*y_names_actual, *y2_names_actual]
+    series_labels = infer_series_labels(
+        all_series_names,
+        omit_units_when_metrics_differ=bool(y2_names_actual),
+    )
+    y_series_actual = list(y_series or [])
+    legend_placement = None
+    if (
+        legend_visible["value"]
+        and context.chart_type in {"line", "scatter"}
+        and context.series_count > 1
+    ):
+        group_sizes = [len(y_names_actual)]
+        if y2_names_actual:
+            group_sizes.append(len(y2_names_actual))
+        legend_placement = recommend_legend_placement(
+            x_values,
+            y_series_actual,
+            labels=series_labels,
+            group_sizes=group_sizes if sum(group_sizes) == len(y_series_actual) else None,
+        )
+    legend_layout = _legend_layout_defaults(
+        visible=bool(legend_visible["value"]),
+        series_count=context.series_count,
+        labels=series_labels,
+        placement=legend_placement,
+    )
+
+    legend_position: dict[str, Any]
+    if not legend_visible["value"]:
+        legend_position = _decision(None, "legend_hidden")
+    elif legend_layout["outside"]["value"]:
+        legend_position = _decision("outside_right", "legend_needs_dedicated_canvas_space")
+    elif context.chart_type in {"line", "scatter"}:
+        legend_position = _decision(
+            (
+                legend_placement["position"]
+                if legend_placement is not None
+                else recommend_legend_position(x_values, y_series_actual)
+            ),
+            "least_occupied_corner_with_sufficient_clearance",
+        )
+    else:
+        legend_position = _decision("inside_upper_right", "stable_compact_anchor")
+
+    symbol_size, transparency = _density_defaults(context)
+    x_rotation = _x_tick_rotation(context)
+    page_aspect_ratio, bottom_margin = _rotated_label_canvas(
+        context,
+        int(x_rotation["value"]),
+    )
+    x_title = infer_axis_title(
+        [x_name] if x_name else [],
+        explicit=x_label,
+        fallback="X",
+    )
+    y_title = infer_axis_title(
+        y_names_actual,
+        explicit=y_label,
+        table=table,
+        title_hint=title_hint,
+        x_name=x_name,
+    )
+    y2_title = (
+        infer_axis_title(
+            y2_names_actual,
+            explicit=y2_label,
+            table=table,
+            title_hint=title_hint,
+            x_name=x_name,
+        )
+        if y2_names_actual or y2_label is not None
+        else None
+    )
+    y_format, y_decimals = _numeric_format(context.y_min, context.y_max)
+    zero_baseline = context.chart_type == "bar" and (
+        context.y_min is None or context.y_min >= 0
+    )
+
+    aspect_ratios = {
+        "line": 1.5,
+        "scatter": 1.5,
+        "bar": 1.35,
+        "box": 1.35,
+        "heatmap": 1.0,
+        "surface": 1.0,
+        "polar": 1.0,
+        "generic": 1.4,
+    }
+    return {
+        "mode": "conservative",
+        "context": asdict(context),
+        "legend": {
+            "show": legend_visible,
+            "position": legend_position,
+            "series_labels": _decision(
+                series_labels,
+                _series_label_reason(all_series_names, series_labels),
+            ),
+            "layout": legend_layout,
+        },
+        "palette_name": palette,
+        "marks": {
+            "symbol_size": symbol_size,
+            "transparency": transparency,
+        },
+        "axes": {
+            "x_title": _decision(
+                x_title.label,
+                x_title.reason,
+                x_title.source,
+            ),
+            "y_title": _decision(
+                y_title.label,
+                y_title.reason,
+                y_title.source,
+            ),
+            "y2_title": _decision(
+                y2_title.label if y2_title is not None else None,
+                y2_title.reason if y2_title is not None else "single_y_axis",
+                y2_title.source if y2_title is not None else "smart_default",
+            ),
+            "x_tick_rotation": x_rotation,
+            "y_number_format": _decision(y_format, "magnitude_and_range"),
+            "y_decimal_places": _decision(y_decimals, "range_appropriate_precision"),
+            "y_zero_baseline": _decision(
+                zero_baseline,
+                "nonnegative_bar_like_chart" if zero_baseline else "preserve_data_range",
+            ),
+        },
+        "canvas": {
+            "aspect_ratio": _decision(
+                aspect_ratios.get(context.chart_type, 1.4),
+                f"{context.chart_type}_chart_footprint",
+            ),
+            "page_aspect_ratio": page_aspect_ratio,
+            "bottom_margin": bottom_margin,
+            "page_width_aspect_ratio": legend_layout["page_width_aspect_ratio"],
+            "right_margin": legend_layout["right_margin"],
+        },
+    }
+
+
+def decision_value(defaults: dict[str, Any], *path: str) -> Any:
+    """Return the value at a nested smart-default decision path."""
+
+    current: Any = defaults
+    for part in path:
+        current = current[part]
+    return current.get("value") if isinstance(current, dict) and "value" in current else current
+
+
+def _decision(value: Any, reason: str, source: str = "smart_default") -> dict[str, Any]:
+    return {"value": value, "source": source, "reason": reason}
+
+
+def _visual_context(
+    *,
+    chart_type: str,
+    series_count: int,
+    row_count: int,
+    x_values: Any,
+    y_series: list[Any],
+) -> VisualContext:
+    raw_chart_type = str(chart_type or "generic").strip().lower().replace("-", "_")
+    x_is_categorical, x_unique_count, longest_x_label = _x_profile(x_values)
+    y_min, y_max = _numeric_extent(y_series)
+    return VisualContext(
+        raw_chart_type=raw_chart_type,
+        chart_type=normalize_chart_type(chart_type),
+        series_count=max(0, int(series_count)),
+        row_count=max(0, int(row_count)),
+        x_is_categorical=x_is_categorical,
+        x_unique_count=x_unique_count,
+        longest_x_label=longest_x_label,
+        y_min=y_min,
+        y_max=y_max,
+    )
+
+
+def _x_profile(values: Any) -> tuple[bool, int, int]:
+    if values is None:
+        return False, 0, 0
+    try:
+        array = np.asarray(values).reshape(-1)
+    except Exception:
+        return False, 0, 0
+    labels = [str(value) for value in array if value is not None and str(value) != "nan"]
+    if not labels:
+        return False, 0, 0
+    try:
+        numeric = np.asarray(labels, dtype=float)
+        is_categorical = not bool(np.all(np.isfinite(numeric)))
+    except (TypeError, ValueError):
+        is_categorical = True
+    return is_categorical, len(set(labels)), max(len(label) for label in labels)
+
+
+def _numeric_extent(series: list[Any]) -> tuple[float | None, float | None]:
+    arrays: list[np.ndarray] = []
+    for values in series:
+        try:
+            array = np.asarray(values, dtype=float).reshape(-1)
+        except (TypeError, ValueError):
+            continue
+        finite = array[np.isfinite(array)]
+        if finite.size:
+            arrays.append(finite)
+    if not arrays:
+        return None, None
+    combined = np.concatenate(arrays)
+    return float(np.min(combined)), float(np.max(combined))
+
+
+def _density_defaults(context: VisualContext) -> tuple[dict[str, Any], dict[str, Any]]:
+    if context.chart_type != "scatter" and context.raw_chart_type not in {
+        "line_symbol",
+        "linesymbol",
+    }:
+        return (
+            _decision(None, "not_a_symbol_density_chart"),
+            _decision(None, "not_a_symbol_density_chart"),
+        )
+    if context.row_count <= 40:
+        return _decision(5.5, "sparse_points"), _decision(0.0, "sparse_points")
+    if context.row_count <= 300:
+        return _decision(4.5, "moderate_point_density"), _decision(10.0, "moderate_point_density")
+    if context.row_count <= 2000:
+        return _decision(3.5, "dense_points"), _decision(35.0, "dense_points")
+    return _decision(2.5, "very_dense_points"), _decision(55.0, "very_dense_points")
+
+
+def _x_tick_rotation(context: VisualContext) -> dict[str, Any]:
+    if not context.x_is_categorical:
+        return _decision(0, "numeric_or_temporal_axis")
+    if context.x_unique_count > 20 or context.longest_x_label > 24:
+        return _decision(90, "many_or_very_long_category_labels")
+    if context.x_unique_count > 8 or context.longest_x_label > 10:
+        return _decision(45, "crowded_category_labels")
+    return _decision(0, "category_labels_fit_horizontally")
+
+
+def _rotated_label_canvas(
+    context: VisualContext,
+    rotation: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Reserve vertical page space for rotated category labels.
+
+    The target page aspect ratio makes this rule idempotent: applying it more
+    than once sets the same height instead of repeatedly multiplying it.
+    """
+
+    if rotation >= 90:
+        return (
+            _decision(0.9, "extra_page_height_for_vertical_category_labels"),
+            _decision(0.35, "reserve_space_for_vertical_category_labels"),
+        )
+    if rotation >= 45:
+        heavily_crowded = (
+            context.x_unique_count >= 12 or context.longest_x_label >= 18
+        )
+        if heavily_crowded:
+            return (
+                _decision(1.05, "extra_page_height_for_long_rotated_category_labels"),
+                _decision(0.25, "reserve_space_for_long_rotated_category_labels"),
+            )
+        return (
+            _decision(1.2, "moderate_page_height_for_rotated_category_labels"),
+            _decision(0.18, "reserve_space_for_rotated_category_labels"),
+        )
+    return (
+        _decision(None, "no_rotated_category_labels"),
+        _decision(None, "no_rotated_category_labels"),
+    )
+
+
+def _legend_layout_defaults(
+    *,
+    visible: bool,
+    series_count: int,
+    labels: list[str],
+    placement: dict[str, Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    lengths = [len(label) for label in labels]
+    longest = max(lengths, default=0)
+    total = sum(lengths)
+    fallback_outside = series_count >= 7 or longest > 24 or total > 90
+    placement_assessed = bool(placement and placement["assessed"])
+    outside = visible and series_count > 1 and (
+        not placement["has_safe_inside"] if placement_assessed else fallback_outside
+    )
+    occupancy_reason = (
+        "all_inside_legend_regions_intersect_data"
+        if placement_assessed
+        else "legend_size_exceeds_safe_plot_overlay"
+    )
+    placement_fields = {
+        "inside_candidate": _decision(
+            placement["position"] if placement is not None else None,
+            "lowest_curve_occupancy_candidate",
+        ),
+        "candidate_collision_fraction": _decision(
+            placement["collision_fraction"] if placement is not None else None,
+            "fraction_of_a_series_intersecting_the_candidate_legend_box",
+        ),
+        "estimated_width_fraction": _decision(
+            placement["width"] if placement is not None else None,
+            "legend_label_footprint_estimate",
+        ),
+        "estimated_height_fraction": _decision(
+            placement["height"] if placement is not None else None,
+            "legend_row_footprint_estimate",
+        ),
+    }
+    if outside:
+        wide = longest > 36 or total > 160
+        return {
+            "outside": _decision(True, occupancy_reason),
+            "estimated_rows": _decision(series_count, "one_series_per_legend_row"),
+            "max_label_length": _decision(longest, "inferred_series_labels"),
+            "page_width_aspect_ratio": _decision(
+                2.0 if wide else 1.8,
+                "widen_canvas_for_external_legend",
+            ),
+            "right_margin": _decision(
+                0.34 if wide else 0.28,
+                "reserve_external_legend_column",
+            ),
+            **placement_fields,
+        }
+    return {
+        "outside": _decision(
+            False,
+            (
+                "data_free_inside_region_available"
+                if placement_assessed
+                else "legend_fits_inside_plot_area"
+            ),
+        ),
+        "estimated_rows": _decision(series_count if visible else 0, "legend_visibility"),
+        "max_label_length": _decision(longest, "inferred_series_labels"),
+        "page_width_aspect_ratio": _decision(None, "no_external_legend"),
+        "right_margin": _decision(None, "no_external_legend"),
+        **placement_fields,
+    }
+
+
+def _series_label_reason(field_names: list[str], labels: list[str]) -> str:
+    if labels and labels != [humanize_field_name(name) for name in field_names]:
+        return "remove_axis_metric_and_unit_from_legend_series"
+    return "humanized_field_names"
+
+
+def _numeric_format(lower: float | None, upper: float | None) -> tuple[str, int]:
+    if lower is None or upper is None:
+        return "decimal", -1
+    magnitude = max(abs(lower), abs(upper))
+    if magnitude >= 100_000 or (0 < magnitude < 0.0001):
+        return "scientific", 2
+    span = abs(upper - lower)
+    if span <= 0:
+        return "decimal", -1
+    approximate_step = span / 5.0
+    decimals = max(0, min(6, int(math.ceil(-math.log10(approximate_step)))))
+    return "decimal", decimals
+
+
+def automatic_histogram_bin_width(values: Any) -> float | None:
+    """Return a robust bin width using Freedman-Diaconis with safe fallbacks.
+
+    The result is clamped to a practical 5-50 bin range for non-trivial data so
+    sparse inputs do not turn into a wall of one-observation bars.
+    """
+
+    try:
+        data = np.asarray(values, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return None
+    data = data[np.isfinite(data)]
+    if data.size < 2:
+        return None
+    lower = float(np.min(data))
+    upper = float(np.max(data))
+    span = upper - lower
+    if not math.isfinite(span) or span <= 0:
+        return None
+
+    count = int(data.size)
+    q25, q75 = np.percentile(data, [25, 75])
+    iqr = float(q75 - q25)
+    width = 2.0 * iqr / math.pow(count, 1.0 / 3.0) if iqr > 0 else 0.0
+    if not math.isfinite(width) or width <= 0:
+        std = float(np.std(data, ddof=1)) if count > 1 else 0.0
+        width = 3.5 * std / math.pow(count, 1.0 / 3.0) if std > 0 else 0.0
+    if not math.isfinite(width) or width <= 0:
+        width = span / max(1, math.ceil(math.sqrt(count)))
+
+    bins = max(1, math.ceil(span / width))
+    unique_count = int(np.unique(data).size)
+    min_bins = min(5, unique_count)
+    max_bins = max(min_bins, min(50, unique_count))
+    bins = min(max(bins, min_bins), max_bins)
+    return span / bins
+
+
+def recommend_legend_position(x_values: Any, y_series: list[Any]) -> str:
+    """Choose the quieter upper corner for a multi-series legend."""
+
+    normalized = _normalized_points(x_values, y_series)
+    if normalized is None:
+        return "inside_upper_right"
+    x_points, y_points = normalized
+    left_score = _corner_density(x_points, y_points, x_anchor=0.12)
+    right_score = _corner_density(x_points, y_points, x_anchor=0.88)
+    return "inside_upper_left" if left_score <= right_score else "inside_upper_right"
+
+
+def recommend_legend_placement(
+    x_values: Any,
+    y_series: list[Any],
+    *,
+    labels: list[str] | None = None,
+    group_sizes: list[int] | None = None,
+) -> dict[str, Any]:
+    """Find an inside corner whose estimated legend rectangle is data-free.
+
+    Each Y-axis group is normalized independently. This matters for dual-Y
+    graphs because values with different units share screen coordinates even
+    though their numeric ranges are unrelated.
+    """
+
+    series_count = len(y_series)
+    longest = max((len(label) for label in labels or []), default=8)
+    raw_width = 0.16 + 0.011 * longest
+    raw_height = 0.05 + 0.065 * series_count
+    width = min(0.58, max(0.22, raw_width))
+    height = min(0.62, max(0.14, raw_height))
+    curves = _normalized_curves(
+        x_values,
+        y_series,
+        group_sizes=group_sizes,
+    )
+    if not curves:
+        return {
+            "position": "inside_upper_right",
+            "has_safe_inside": False,
+            "assessed": False,
+            "collision_fraction": None,
+            "width": width,
+            "height": height,
+        }
+
+    margin = 0.025
+    padding = 0.025
+    candidates = [
+        ("inside_upper_right", 1 - margin - width, 1 - margin, 1 - margin - height, 1 - margin),
+        ("inside_upper_left", margin, margin + width, 1 - margin - height, 1 - margin),
+        ("inside_lower_right", 1 - margin - width, 1 - margin, margin, margin + height),
+        ("inside_lower_left", margin, margin + width, margin, margin + height),
+    ]
+    scored: list[tuple[float, float, str]] = []
+    for position, x_min, x_max, y_min, y_max in candidates:
+        collision = max(
+            float(
+                np.mean(
+                    (curve_x >= x_min - padding)
+                    & (curve_x <= x_max + padding)
+                    & (curve_y >= y_min - padding)
+                    & (curve_y <= y_max + padding)
+                )
+            )
+            for curve_x, curve_y in curves
+        )
+        # Prefer upper corners when equally clear; lower legends more often
+        # compete with the X axis and the beginning/end of a line trajectory.
+        preference_penalty = 0.002 if "lower" in position else 0.0
+        scored.append((collision + preference_penalty, collision, position))
+    _effective_score, collision_fraction, position = min(scored)
+    footprint_fits = raw_width <= 0.48 and raw_height <= 0.55
+    return {
+        "position": position,
+        "has_safe_inside": footprint_fits and collision_fraction <= 0.002,
+        "assessed": True,
+        "collision_fraction": round(collision_fraction, 6),
+        "width": round(width, 4),
+        "height": round(height, 4),
+    }
+
+
+def _normalized_curves(
+    x_values: Any,
+    y_series: list[Any],
+    *,
+    group_sizes: list[int] | None,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    if not y_series:
+        return []
+    try:
+        arrays = [np.asarray(values, dtype=float).reshape(-1) for values in y_series]
+    except (TypeError, ValueError):
+        return []
+    length = max((array.size for array in arrays), default=0)
+    try:
+        x_array = np.asarray(x_values, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        x_array = np.arange(length, dtype=float)
+    if x_array.size == 0:
+        x_array = np.arange(length, dtype=float)
+
+    groups = _series_groups(len(arrays), group_sizes)
+    curves: list[tuple[np.ndarray, np.ndarray]] = []
+    for indexes in groups:
+        finite_y = [array[np.isfinite(array)] for array in (arrays[index] for index in indexes)]
+        finite_y = [array for array in finite_y if array.size]
+        if not finite_y:
+            continue
+        combined_y = np.concatenate(finite_y)
+        y_min = float(np.min(combined_y))
+        y_span = float(np.max(combined_y) - y_min)
+        if y_span <= 0:
+            continue
+        for index in indexes:
+            values = arrays[index]
+            usable = min(x_array.size, values.size)
+            if usable <= 1:
+                continue
+            x_part = x_array[:usable]
+            y_part = values[:usable]
+            mask = np.isfinite(x_part) & np.isfinite(y_part)
+            if np.count_nonzero(mask) <= 1:
+                continue
+            x_valid = x_part[mask]
+            y_valid = y_part[mask]
+            x_min = float(np.min(x_valid))
+            x_span = float(np.max(x_valid) - x_min)
+            if x_span <= 0:
+                continue
+            x_normalized = (x_valid - x_min) / x_span
+            y_normalized = (y_valid - y_min) / y_span
+            order = np.argsort(x_normalized)
+            unique_x, unique_indexes = np.unique(x_normalized[order], return_index=True)
+            unique_y = y_normalized[order][unique_indexes]
+            if unique_x.size <= 1:
+                continue
+            dense_x = np.linspace(float(unique_x[0]), float(unique_x[-1]), 200)
+            dense_y = np.interp(dense_x, unique_x, unique_y)
+            curves.append((dense_x, dense_y))
+    return curves
+
+
+def _series_groups(series_count: int, group_sizes: list[int] | None) -> list[list[int]]:
+    if not group_sizes or any(size <= 0 for size in group_sizes):
+        return [list(range(series_count))]
+    groups: list[list[int]] = []
+    start = 0
+    for size in group_sizes:
+        stop = min(series_count, start + size)
+        if stop > start:
+            groups.append(list(range(start, stop)))
+        start = stop
+    if start < series_count:
+        groups.append(list(range(start, series_count)))
+    return groups
+
+
+def _normalized_points(x_values: Any, y_series: list[Any]) -> tuple[np.ndarray, np.ndarray] | None:
+    if not y_series:
+        return None
+    try:
+        y_arrays = [np.asarray(values, dtype=float).reshape(-1) for values in y_series]
+    except (TypeError, ValueError):
+        return None
+    if not y_arrays:
+        return None
+    length = max(array.size for array in y_arrays)
+    try:
+        x_array = np.asarray(x_values, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        x_array = np.arange(length, dtype=float)
+
+    xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+    for values in y_arrays:
+        usable = min(x_array.size, values.size)
+        if usable <= 0:
+            continue
+        x_part = x_array[:usable]
+        y_part = values[:usable]
+        mask = np.isfinite(x_part) & np.isfinite(y_part)
+        if np.any(mask):
+            xs.append(x_part[mask])
+            ys.append(y_part[mask])
+    if not xs:
+        return None
+    x_all = np.concatenate(xs)
+    y_all = np.concatenate(ys)
+    x_span = float(np.max(x_all) - np.min(x_all))
+    y_span = float(np.max(y_all) - np.min(y_all))
+    if x_span <= 0 or y_span <= 0:
+        return None
+    return (
+        (x_all - np.min(x_all)) / x_span,
+        (y_all - np.min(y_all)) / y_span,
+    )
+
+
+def _corner_density(x_values: np.ndarray, y_values: np.ndarray, *, x_anchor: float) -> float:
+    distance_sq = np.square(x_values - x_anchor) + np.square(y_values - 0.88)
+    return float(np.exp(-distance_sq / (2.0 * 0.22**2)).sum())

--- a/tests/test_graph_mixin.py
+++ b/tests/test_graph_mixin.py
@@ -48,6 +48,116 @@ def test_plot_table_creates_graph_and_plots(fake_client: OriginClient, tmp_path:
     # Axis titles were applied via format_graph.
     assert page[0].axis("x").title == "X axis"
     assert page[0].axis("y").title == "Y axis"
+    sheet = fake_client.op.books[-1][0]
+    assert sheet.label_calls[-1] == (["X", "Y1", "Y2"], "L", 0)
+
+
+def test_plot_table_humanizes_default_labels_and_units(
+    fake_client: OriginClient,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "dose.csv"
+    path.write_text("dose_uM,measured_response\n1,2\n2,4\n", encoding="utf-8")
+
+    fake_client.plot_table(
+        path=path,
+        kind="line",
+        x_col="dose_uM",
+        y_cols=["measured_response"],
+        show_legend=False,
+    )
+
+    page = fake_client.op.graphs[-1]
+    assert page[0].axis("x").title == r"Dose (\x(00B5)M)"
+    assert page[0].axis("y").title == "Measured response"
+    sheet = fake_client.op.books[-1][0]
+    assert sheet.label_calls[-1] == (
+        [r"Dose (\x(00B5)M)", "Measured response"],
+        "L",
+        0,
+    )
+
+
+def test_plot_table_uses_shared_axis_title_and_compact_legend_labels(
+    fake_client: OriginClient,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "temperature.csv"
+    path.write_text(
+        "time_s,temperature_control_C,temperature_treated_C\n0,20,21\n1,22,24\n",
+        encoding="utf-8",
+    )
+
+    _, graph = fake_client.plot_table(
+        path=path,
+        kind="line",
+        x_col="time_s",
+        y_cols=["temperature_control_C", "temperature_treated_C"],
+    )
+
+    page = fake_client.op.graphs[-1]
+    sheet = fake_client.op.books[-1][0]
+    assert page[0].axis("x").title == "Time (s)"
+    assert page[0].axis("y").title == r"Temperature (\x(00B0)C)"
+    assert sheet.label_calls[-1] == (
+        ["Time (s)", "Control", "Treated"],
+        "L",
+        0,
+    )
+    assert graph.visual_defaults is not None
+    assert graph.visual_defaults["axes"]["y_title"]["reason"] == "shared_metric_and_unit"
+
+
+def test_plot_table_binds_plots_before_setting_display_labels(
+    fake_client: OriginClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    csv = _write_csv(tmp_path)
+    events: list[str] = []
+    original_add_plot = fake_client._add_plot
+    original_set_labels = fake_client._set_worksheet_display_labels
+
+    def record_add_plot(*args: Any, **kwargs: Any) -> None:
+        events.append("add_plot")
+        original_add_plot(*args, **kwargs)
+
+    def record_set_labels(*args: Any, **kwargs: Any) -> None:
+        events.append("set_labels")
+        original_set_labels(*args, **kwargs)
+
+    monkeypatch.setattr(fake_client, "_add_plot", record_add_plot)
+    monkeypatch.setattr(fake_client, "_set_worksheet_display_labels", record_set_labels)
+
+    fake_client.plot_table(
+        path=csv,
+        kind="line",
+        x_col="x",
+        y_cols=["y1", "y2"],
+    )
+
+    assert events == ["add_plot", "add_plot", "set_labels"]
+
+
+def test_plot_table_rescales_after_setting_histogram_bin_width(
+    fake_client: OriginClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    csv = _write_csv(tmp_path)
+    rescale_calls: list[Any] = []
+    monkeypatch.setattr(fake_client, "_rescale", rescale_calls.append)
+
+    fake_client.plot_table(
+        path=csv,
+        kind="histogram",
+        y_cols=["y1"],
+        histogram_bin_width="auto",
+    )
+
+    # Once during general graph formatting, then again after the bin width
+    # changes the histogram counts.
+    assert len(rescale_calls) == 2
 
 
 def test_plot_table_exports_when_requested(fake_client: OriginClient, tmp_path: Path) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_plot_table_request_defaults(tmp_path: Path) -> None:
 
     assert req.x_col is None
     assert req.y_cols is None
-    assert req.show_legend is True
+    assert req.show_legend is None
 
 
 def test_figurespec_validates_references(tmp_path: Path) -> None:

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -8,7 +8,12 @@ from typing import Any
 import pandas as pd
 import pytest
 
-from origin_mcp.chart_palette import normalize_palette_name, palette_catalog
+from origin_mcp.chart_palette import (
+    named_palette,
+    normalize_palette_name,
+    palette_catalog,
+    select_palette_for_count,
+)
 from origin_mcp.compat import PLOT_TYPE_CATALOG
 from origin_mcp.errors import OriginOperationError
 from origin_mcp.origin_client import GraphRef, OriginClient, WorksheetRef
@@ -992,6 +997,29 @@ def test_format_legend_positions_inside_layer_anchor_when_requested(
     assert "legend.top" not in scripts[-1]
 
 
+def test_format_legend_positions_outside_right_when_canvas_is_reserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OriginClient()
+    legend = FakeLabel("Legend")
+    layer = FakeLayer()
+    layer.labels["Legend"] = legend
+    graph = FakeGraph(layer)
+    scripts = []
+    monkeypatch.setattr(client, "_find_or_active_graph", lambda _name: graph)
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+
+    result = client.format_legend("Graph1", position="outside_right")
+
+    assert "layer.x.to+(layer.x.to-layer.x.from)*0.04+legend.dx/2" in scripts[-1]
+    assert "layer.y.to-legend.dy/2" in scripts[-1]
+    assert result["position"]["position"] == "outside_right"
+
+
 def test_format_legend_interprets_small_left_top_as_layer_percent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1485,7 +1513,130 @@ def test_plot_table_nature_style_applies_override(
     )
 
     assert graph_ref.style_mode == "nature"
-    assert nature_calls == [{"graph_name": "Graph1", "chart_type": "line"}]
+    assert graph_ref.visual_defaults is not None
+    assert graph_ref.visual_defaults["legend"]["show"]["source"] == "user"
+    assert graph_ref.visual_defaults["palette_name"]["value"] == "lcpmgh_auto"
+    assert nature_calls == [
+        {
+            "graph_name": "Graph1",
+            "chart_type": "line",
+            "show_legend": False,
+            "palette_name": "lcpmgh_auto",
+        }
+    ]
+
+
+def test_apply_smart_visual_defaults_formats_axes_marks_and_legend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OriginClient()
+    scripts = []
+    style_calls = []
+    legend_calls = []
+    defaults = {
+        "legend": {
+            "show": {"value": True},
+            "position": {"value": "inside_upper_left"},
+        },
+        "marks": {
+            "symbol_size": {"value": 3.5},
+            "transparency": {"value": 35.0},
+        },
+        "axes": {
+            "x_tick_rotation": {"value": 45},
+            "y_number_format": {"value": "scientific"},
+            "y_decimal_places": {"value": 2},
+            "y_zero_baseline": {"value": True},
+        },
+        "canvas": {
+            "page_aspect_ratio": {"value": 1.05},
+            "bottom_margin": {"value": 0.25},
+        },
+    }
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+    monkeypatch.setattr(
+        client,
+        "set_plot_style",
+        lambda **kwargs: style_calls.append(kwargs) or {"styled": True},
+    )
+    monkeypatch.setattr(
+        client,
+        "format_legend",
+        lambda **kwargs: legend_calls.append(kwargs) or {"formatted": True},
+    )
+
+    result = client._apply_smart_visual_defaults(
+        graph_name="Graph1",
+        defaults=defaults,
+    )
+
+    assert "layer.x.label.rotate=45;" in scripts[0]
+    assert "layer.y.label.numFormat=2;" in scripts[0]
+    assert "layer.y.label.decPlaces=2;" in scripts[0]
+    assert "layer.y.from=0;" in scripts[0]
+    assert "page.height=page.width/1.05;" in scripts[0]
+    assert "page -fls -u -ml 0.08 -mt 0.05 -mr 0.05 -mb 0.25;" in scripts[0]
+    assert style_calls == [
+        {"graph_name": "Graph1", "symbol_size": 3.5, "transparency": 35.0}
+    ]
+    assert legend_calls == [
+        {
+            "graph_name": "Graph1",
+            "show_frame": False,
+            "position": "inside_upper_left",
+        }
+    ]
+    assert result["axis_result"]["result"] is True
+
+
+def test_apply_smart_visual_defaults_widens_canvas_for_external_legend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OriginClient()
+    scripts = []
+    legend_calls = []
+    defaults = {
+        "legend": {
+            "show": {"value": True},
+            "position": {"value": "outside_right"},
+        },
+        "marks": {
+            "symbol_size": {"value": None},
+            "transparency": {"value": None},
+        },
+        "axes": {
+            "x_tick_rotation": {"value": 0},
+            "y_number_format": {"value": "decimal"},
+            "y_decimal_places": {"value": 1},
+            "y_zero_baseline": {"value": False},
+        },
+        "canvas": {
+            "page_aspect_ratio": {"value": None},
+            "bottom_margin": {"value": None},
+            "page_width_aspect_ratio": {"value": 1.8},
+            "right_margin": {"value": 0.28},
+        },
+    }
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+    monkeypatch.setattr(
+        client,
+        "format_legend",
+        lambda **kwargs: legend_calls.append(kwargs) or {"formatted": True},
+    )
+
+    client._apply_smart_visual_defaults(graph_name="Graph1", defaults=defaults)
+
+    assert "page.width=page.height*1.8;" in scripts[0]
+    assert "-mr 0.28 -mb 0.08;" in scripts[0]
+    assert legend_calls[0]["position"] == "outside_right"
 
 
 def test_plot_table_exports_by_graph_name(
@@ -1626,8 +1777,8 @@ def test_apply_nature_style_updates_plots(monkeypatch: pytest.MonkeyPatch) -> No
     assert "layer.x.ticklabel.font=font(Arial);" in scripts[-1]
     assert "xb.font=font(Arial);" in scripts[-1]
     assert "yl.font=font(Arial);" in scripts[-1]
-    assert 'xb.text$="\\f:Arial(Axis)";' in scripts[-1]
-    assert 'yl.text$="\\f:Arial(Axis)";' in scripts[-1]
+    assert 'xb.text$="Axis";' in scripts[-1]
+    assert 'yl.text$="Axis";' in scripts[-1]
     assert "layer.x.label.pt=20;" in scripts[-1]
     assert "layer.y.label.pt=20;" in scripts[-1]
     assert "layer.x.ticklabel.pt=18;" in scripts[-1]
@@ -1727,6 +1878,27 @@ def test_apply_nature_style_uses_semantic_palette_roles(
     assert result["diagnostics"]["checklist"][3]["passed"] is True
 
 
+def test_apply_nature_style_continues_palette_across_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OriginClient()
+    plots = [FakePlot() for _ in range(4)]
+    graph = FakeGraph([FakeLayer(plots[:2]), FakeLayer(plots[2:])])
+    monkeypatch.setattr(client, "_find_or_active_graph", lambda _name: graph)
+    monkeypatch.setattr(client, "run_labtalk", lambda _script: {"result": True})
+    monkeypatch.setattr(client, "format_legend", lambda *_args, **_kwargs: {"legend": True})
+
+    result = client.apply_nature_style("Graph1", palette_name="nature")
+
+    assert [plot.color for plot in plots] == named_palette("nature")[:4]
+    assert result["applied_palette_roles"] == [
+        "category_1",
+        "category_2",
+        "category_3",
+        "category_4",
+    ]
+
+
 def test_palette_catalog_exposes_lcpmgh_nature_source() -> None:
     catalog = palette_catalog()
 
@@ -1763,6 +1935,13 @@ def test_palette_catalog_filters_lcpmgh_color_range() -> None:
     assert catalog
     assert all(6 <= entry["colors_count"] <= 8 for entry in catalog.values())
     assert all("colors" not in entry for entry in catalog.values())
+
+
+def test_auto_palette_prefers_readable_hue_separated_exact_count_palette() -> None:
+    palette_name, palette = select_palette_for_count(4)
+
+    assert palette_name == "lcpmgh_004_014"
+    assert palette["palette"] == ["#6A8EC9", "#E84446", "#59B78F", "#7A378A"]
 
 
 def test_apply_nature_style_uses_named_palette(
@@ -2365,6 +2544,90 @@ def test_plot_table_by_id_builds_labtalk_command(
     assert any('title.show=0; title.text$="";' in script for script in scripts)
 
 
+def test_plot_table_by_id_applies_requested_visual_defaults_before_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("duration_s\n0.2\n0.4\n0.5\n0.8\n1.3\n1.6\n", encoding="utf-8")
+    client = OriginClient()
+    wks = FakeWorksheet()
+    style_calls = []
+    format_calls = []
+    scripts: list[str] = []
+    monkeypatch.setattr(client, "_new_sheet", lambda **_kwargs: wks)
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+    monkeypatch.setattr(
+        client,
+        "set_plot_style",
+        lambda **kwargs: style_calls.append(kwargs) or {"applied": kwargs},
+    )
+    monkeypatch.setattr(
+        client,
+        "format_graph",
+        lambda **kwargs: format_calls.append(kwargs) or {"formatted": True},
+    )
+
+    _worksheet, _graph, command = client.plot_table_by_id(
+        path=path,
+        plot_type_id=219,
+        template="hist",
+        selected_cols=["duration_s"],
+        graph_name="Histogram",
+        histogram_bin_width="auto",
+    )
+
+    assert style_calls[0]["graph_name"] == "Histogram"
+    assert style_calls[0]["histogram_bin_width"] > 0
+    assert {"graph_name": "Histogram", "rescale": True} in format_calls
+    bin_width = style_calls[0]["histogram_bin_width"]
+    worksheet_script = "worksheet -s 1 0 1 0; worksheet -p 219 hist;"
+    assert scripts.index(f"@HBS={bin_width:g};") < next(
+        index for index, script in enumerate(scripts) if script == worksheet_script
+    )
+    assert scripts.index("@HBS=-1;") > next(
+        index for index, script in enumerate(scripts) if script == worksheet_script
+    )
+    assert command["command"] == "worksheet"
+    assert command["range_option"] == "selection"
+    assert not any("plotxy" in script and "plot:=219" in script for script in scripts)
+    assert "histogram_bin_width" in command["visual_defaults"]
+
+
+def test_plot_table_by_id_applies_explicit_heatmap_colormap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("x,y,z\n0,0,1\n0,1,2\n1,0,3\n1,1,4\n", encoding="utf-8")
+    client = OriginClient()
+    wks = FakeWorksheet()
+    style_calls = []
+    monkeypatch.setattr(client, "_new_sheet", lambda **_kwargs: wks)
+    monkeypatch.setattr(client, "run_labtalk", lambda _script: {"result": True})
+    monkeypatch.setattr(
+        client,
+        "set_plot_style",
+        lambda **kwargs: style_calls.append(kwargs) or {"applied": kwargs},
+    )
+
+    _worksheet, _graph, command = client.plot_table_by_id(
+        path=path,
+        plot_type_id=243,
+        template="Contour",
+        selected_cols=["x", "y", "z"],
+        graph_name="Heatmap",
+        colormap="viridis",
+    )
+
+    assert style_calls == [{"graph_name": "Heatmap", "colormap": "viridis"}]
+    assert command["visual_defaults"]["colormap"]["applied"]["colormap"] == "viridis"
+
+
 def test_plot_table_by_id_reuses_named_graph_when_present(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2565,7 +2828,20 @@ def test_plot_table_by_id_worksheet_command_prefers_new_graph_over_existing_name
 def test_all_documented_table_plot_ids_use_expected_labtalk_routes() -> None:
     matrix_only_ids = {item["id"] for item in PLOT_TYPE_CATALOG if item["input"] == "Matrix Object"}
     expected_plotxyz_ids = {103, 185, 240, 242, 243, 245}
-    expected_worksheet_ids = {183, 184, 206, 210, 211, 212, 214, 215, 216, 225, 249}
+    expected_worksheet_ids = {
+        183,
+        184,
+        206,
+        210,
+        211,
+        212,
+        214,
+        215,
+        216,
+        219,
+        225,
+        249,
+    }
 
     for item in PLOT_TYPE_CATALOG:
         plot_type_id = item["id"]
@@ -2643,7 +2919,14 @@ def test_plot_table_by_id_nature_style_applies_override(
     )
 
     assert graph.style_mode == "nature"
-    assert nature_calls == [{"graph_name": "NatureLine", "chart_type": "line"}]
+    assert nature_calls == [
+        {
+            "graph_name": "NatureLine",
+            "chart_type": "line",
+            "show_legend": False,
+            "palette_name": "lcpmgh_auto",
+        }
+    ]
 
 
 def test_plot_table_by_id_exports_active_graph_when_named_graph_missing(
@@ -3224,7 +3507,64 @@ def test_plot_dual_y_nature_style_applies_override(
     assert len(right.added) == 1
     assert graph_ref.template == "doubleY"
     assert graph_ref.style_mode == "nature"
-    assert nature_calls == [{"graph_name": "Graph1", "chart_type": "line_symbol"}]
+    assert nature_calls == [
+        {
+            "graph_name": "Graph1",
+            "chart_type": "line_symbol",
+            "show_legend": True,
+            "palette_name": "lcpmgh_auto",
+        }
+    ]
+
+
+def test_plot_dual_y_infers_separate_concise_axis_titles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "dual_semantic.csv"
+    path.write_text(
+        "time_s,temperature_control_C,temperature_treated_C,"
+        "pressure_control_kPa,pressure_treated_kPa\n"
+        "0,20,21,100,102\n1,22,24,105,108\n",
+        encoding="utf-8",
+    )
+    client = OriginClient()
+    worksheet = FakeWorksheet()
+    left = FakeLayer()
+    right = FakeLayer()
+    graph = FakeGraph([left, right])
+    scripts = []
+    monkeypatch.setattr(client, "_new_sheet", lambda **_kwargs: worksheet)
+    monkeypatch.setattr(client, "_new_graph", lambda **_kwargs: graph)
+    monkeypatch.setattr(client, "_rescale", lambda _layer: None)
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+
+    _, graph_ref = client.plot_dual_y(
+        path=path,
+        x_col="time_s",
+        y1_cols=["temperature_control_C", "temperature_treated_C"],
+        y2_cols=["pressure_control_kPa", "pressure_treated_kPa"],
+        show_legend=False,
+    )
+
+    assert left.axis("x").title == "Time (s)"
+    assert left.axis("y").title == r"Temperature (\x(00B0)C)"
+    assert right.axis("y").title == "Pressure (kPa)"
+    assert left.group_calls == 0
+    assert right.group_calls == 0
+    assert graph_ref.visual_defaults is not None
+    assert graph_ref.visual_defaults["axes"]["y2_title"]["value"] == "Pressure (kPa)"
+    assert graph_ref.visual_defaults["legend"]["series_labels"]["value"] == [
+        "Temperature control",
+        "Temperature treated",
+        "Pressure control",
+        "Pressure treated",
+    ]
+    assert any('yr.text$="Pressure (kPa)";' in script for script in scripts)
 
 
 def test_add_inset_layer_requires_x_and_y_cols() -> None:

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -1580,9 +1580,7 @@ def test_apply_smart_visual_defaults_formats_axes_marks_and_legend(
     assert "layer.y.from=0;" in scripts[0]
     assert "page.height=page.width/1.05;" in scripts[0]
     assert "page -fls -u -ml 0.08 -mt 0.05 -mr 0.05 -mb 0.25;" in scripts[0]
-    assert style_calls == [
-        {"graph_name": "Graph1", "symbol_size": 3.5, "transparency": 35.0}
-    ]
+    assert style_calls == [{"graph_name": "Graph1", "symbol_size": 3.5, "transparency": 35.0}]
     assert legend_calls == [
         {
             "graph_name": "Graph1",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -477,6 +477,8 @@ def test_heatmap_wrapper_routes_xyz_data_through_plot_type_id(
     assert calls[0]["template"] == "Contour"
     assert calls[0]["selected_cols"] == ["x", "y", "z"]
     assert calls[0]["graph_name"] == "Heat"
+    assert calls[0]["colormap"] == "viridis"
+    assert calls[0]["show_legend"] is None
 
 
 def test_origin_plot_routes_kind_through_plot_type_id(monkeypatch, tmp_path: Path) -> None:
@@ -495,6 +497,7 @@ def test_origin_plot_routes_kind_through_plot_type_id(monkeypatch, tmp_path: Pat
         kind="bar",
         selected_cols=["x", "y"],
         graph_name="Bar",
+        palette_name="lcpmgh_002_001",
     )
 
     assert result["ok"] is True
@@ -502,6 +505,7 @@ def test_origin_plot_routes_kind_through_plot_type_id(monkeypatch, tmp_path: Pat
     assert calls[0]["template"] == "bar"
     assert calls[0]["selected_cols"] == ["x", "y"]
     assert calls[0]["graph_name"] == "Bar"
+    assert calls[0]["palette_name"] == "lcpmgh_002_001"
 
 
 def test_origin_plot_routes_common_kind_through_table_plot(monkeypatch, tmp_path: Path) -> None:
@@ -520,6 +524,7 @@ def test_origin_plot_routes_common_kind_through_table_plot(monkeypatch, tmp_path
         kind="line",
         selected_cols=["x", "y"],
         graph_name="Line",
+        palette_name="nature",
     )
 
     assert result["ok"] is True
@@ -527,6 +532,7 @@ def test_origin_plot_routes_common_kind_through_table_plot(monkeypatch, tmp_path
     assert calls[0]["x_col"] == "x"
     assert calls[0]["y_cols"] == ["y"]
     assert calls[0]["graph_name"] == "Line"
+    assert calls[0]["palette_name"] == "nature"
 
 
 def test_origin_plot_rejects_unknown_kind(tmp_path: Path) -> None:
@@ -550,7 +556,6 @@ def test_distribution_wrappers_route_through_plot_type_id(monkeypatch, tmp_path:
     path = tmp_path / "distribution.csv"
     path.write_text("x,y,z\n0,1,2\n", encoding="utf-8")
     calls = []
-    legend_calls = []
 
     def fake_plot_table_id(**kwargs):
         calls.append(kwargs)
@@ -561,12 +566,6 @@ def test_distribution_wrappers_route_through_plot_type_id(monkeypatch, tmp_path:
         }
 
     monkeypatch.setattr(plotting_basic_tools, "_plot_table_id", fake_plot_table_id)
-    monkeypatch.setattr(
-        plotting_basic_tools.client,
-        "format_graph",
-        lambda **kwargs: legend_calls.append(kwargs) or {"formatted": True},
-    )
-
     histogram = server.origin_plot_histogram(
         str(path),
         x_col="y",
@@ -582,11 +581,10 @@ def test_distribution_wrappers_route_through_plot_type_id(monkeypatch, tmp_path:
         (206, "box"),
     ]
     assert calls[0]["selected_cols"] == ["y"]
+    assert calls[0]["histogram_bin_width"] == "auto"
+    assert calls[0]["show_legend"] is False
     assert calls[1]["selected_cols"] == ["y", "z"]
-    assert legend_calls == [
-        {"graph_name": "Hist", "show_legend": False, "rescale": False},
-        {"graph_name": "Box", "show_legend": True, "rescale": False},
-    ]
+    assert calls[1]["show_legend"] is None
 
 
 def test_dual_y_wrapper_passes_style_mode(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -43,15 +43,14 @@ def test_humanize_field_name_formats_words_acronyms_and_units() -> None:
 
 
 def test_axis_title_inference_extracts_shared_metric_and_unit() -> None:
-    inferred = infer_axis_title(
-        ["glucose_control_mg_dL", "glucose_treated_mg_dL"]
-    )
+    inferred = infer_axis_title(["glucose_control_mg_dL", "glucose_treated_mg_dL"])
 
     assert inferred.label == "Glucose (mg/dL)"
     assert inferred.unit == "mg/dL"
-    assert infer_series_labels(
-        ["glucose_control_mg_dL", "glucose_treated_mg_dL"]
-    ) == ["Control", "Treated"]
+    assert infer_series_labels(["glucose_control_mg_dL", "glucose_treated_mg_dL"]) == [
+        "Control",
+        "Treated",
+    ]
 
 
 def test_axis_title_inference_understands_statistics_and_temperature_unit() -> None:

--- a/tests/test_text_format.py
+++ b/tests/test_text_format.py
@@ -1,4 +1,11 @@
-from origin_mcp.text_format import origin_rich_text
+import pandas as pd
+
+from origin_mcp.text_format import (
+    humanize_field_name,
+    infer_axis_title,
+    infer_series_labels,
+    origin_rich_text,
+)
 
 
 def test_origin_rich_text_converts_unicode_super_and_subscripts() -> None:
@@ -20,3 +27,76 @@ def test_origin_rich_text_avoids_multi_letter_identifier_underscores() -> None:
 
 def test_origin_rich_text_preserves_existing_origin_escape_sequences() -> None:
     assert origin_rich_text("CO\\-(2)") == "CO\\-(2)"
+
+
+def test_origin_rich_text_converts_common_unit_symbols_to_unicode_escapes() -> None:
+    assert origin_rich_text("Dose (μM), 25 °C") == r"Dose (\x(00B5)M), 25 \x(00B0)C"
+
+
+def test_humanize_field_name_formats_words_acronyms_and_units() -> None:
+    assert humanize_field_name("measured_response") == "Measured response"
+    assert humanize_field_name("origin_mcp_minutes") == "Origin MCP minutes"
+    assert humanize_field_name("dose_uM") == r"Dose (\x(00B5)M)"
+    assert humanize_field_name("duration_s") == "Duration (s)"
+    assert humanize_field_name("temperature_C") == r"Temperature (\x(00B0)C)"
+    assert humanize_field_name("glucose_mg_dL") == "Glucose (mg/dL)"
+
+
+def test_axis_title_inference_extracts_shared_metric_and_unit() -> None:
+    inferred = infer_axis_title(
+        ["glucose_control_mg_dL", "glucose_treated_mg_dL"]
+    )
+
+    assert inferred.label == "Glucose (mg/dL)"
+    assert inferred.unit == "mg/dL"
+    assert infer_series_labels(
+        ["glucose_control_mg_dL", "glucose_treated_mg_dL"]
+    ) == ["Control", "Treated"]
+
+
+def test_axis_title_inference_understands_statistics_and_temperature_unit() -> None:
+    inferred = infer_axis_title(["temperature_mean_C", "temperature_std_C"])
+
+    assert inferred.label == r"Temperature (\x(00B0)C)"
+    assert infer_series_labels(["temperature_mean_C", "temperature_std_C"]) == [
+        "Mean",
+        "SD",
+    ]
+
+
+def test_axis_title_inference_uses_value_unit_table_structure() -> None:
+    table = pd.DataFrame(
+        {
+            "sample": ["A", "B"],
+            "metric": ["Temperature", "Temperature"],
+            "value": [25.2, 26.1],
+            "unit": ["C", "C"],
+        }
+    )
+
+    inferred = infer_axis_title(["value"], table=table)
+
+    assert inferred.label == r"Temperature (\x(00B0)C)"
+    assert inferred.reason == "table_metric_unit_columns"
+
+
+def test_axis_title_inference_uses_chart_title_when_fields_only_name_series() -> None:
+    inferred = infer_axis_title(
+        ["compound_a", "compound_b", "compound_c"],
+        title_hint="Dose response comparison",
+        x_name="dose_uM",
+    )
+
+    assert inferred.label == "Response"
+    assert infer_series_labels(["compound_a", "compound_b", "compound_c"]) == [
+        "Compound a",
+        "Compound b",
+        "Compound c",
+    ]
+
+
+def test_infer_series_labels_can_omit_units_for_dual_axis_legend() -> None:
+    assert infer_series_labels(
+        ["temperature_control_C", "pressure_control_kPa"],
+        omit_units_when_metrics_differ=True,
+    ) == ["Temperature control", "Pressure control"]

--- a/tests/test_visual_defaults.py
+++ b/tests/test_visual_defaults.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import numpy as np
+
+from origin_mcp.visual_defaults import (
+    automatic_histogram_bin_width,
+    decision_value,
+    recommend_legend_placement,
+    recommend_legend_position,
+    resolve_visual_defaults,
+)
+
+
+def test_automatic_histogram_bin_width_is_robust_and_bounded() -> None:
+    values = np.linspace(0.0, 99.0, 100)
+
+    width = automatic_histogram_bin_width(values)
+
+    assert width is not None
+    bins = int(np.ceil((values.max() - values.min()) / width))
+    assert 5 <= bins <= 50
+
+
+def test_automatic_histogram_bin_width_handles_degenerate_data() -> None:
+    assert automatic_histogram_bin_width([1.0]) is None
+    assert automatic_histogram_bin_width([2.0, 2.0, 2.0]) is None
+
+
+def test_legend_position_avoids_increasing_series_upper_right() -> None:
+    x = np.arange(10)
+    assert recommend_legend_position(x, [x, x + 1]) == "inside_upper_left"
+
+
+def test_legend_position_avoids_decreasing_series_upper_left() -> None:
+    x = np.arange(10)
+    assert recommend_legend_position(x, [10 - x, 9 - x]) == "inside_upper_right"
+
+
+def test_smart_defaults_hide_redundant_legend_but_respect_override() -> None:
+    automatic = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=10,
+        x_values=np.arange(10),
+        y_series=[np.arange(10)],
+    )
+    explicit = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=10,
+        show_legend=True,
+    )
+
+    assert decision_value(automatic, "legend", "show") is False
+    assert automatic["legend"]["show"]["reason"] == "single_series"
+    assert decision_value(explicit, "legend", "show") is True
+    assert explicit["legend"]["show"]["source"] == "user"
+
+
+def test_smart_defaults_choose_installed_palette_for_nature_multi_series() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=3,
+        row_count=20,
+        x_values=np.arange(20),
+        y_series=[np.arange(20), np.arange(20) + 1, np.arange(20) + 2],
+        style_mode="nature",
+    )
+
+    assert decision_value(defaults, "palette_name") == "lcpmgh_auto"
+    assert decision_value(defaults, "legend", "show") is True
+    assert decision_value(defaults, "legend", "position") == "inside_upper_left"
+
+
+def test_smart_defaults_explain_axis_titles_and_series_labels() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=2,
+        row_count=20,
+        x_values=np.arange(20),
+        y_series=[np.arange(20), np.arange(20) + 1],
+        x_name="time_s",
+        y_names=["temperature_control_C", "temperature_treated_C"],
+    )
+
+    assert decision_value(defaults, "axes", "x_title") == "Time (s)"
+    assert decision_value(defaults, "axes", "y_title") == r"Temperature (\x(00B0)C)"
+    assert decision_value(defaults, "legend", "series_labels") == [
+        "Control",
+        "Treated",
+    ]
+
+
+def test_smart_defaults_move_large_legend_outside_and_widen_canvas() -> None:
+    names = [f"response_condition_{index}" for index in range(8)]
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=len(names),
+        row_count=20,
+        x_values=np.arange(20),
+        y_series=[np.arange(20) + index for index in range(len(names))],
+        x_name="time_s",
+        y_names=names,
+    )
+
+    assert decision_value(defaults, "legend", "position") == "outside_right"
+    assert decision_value(defaults, "legend", "layout", "outside") is True
+    assert decision_value(defaults, "canvas", "page_width_aspect_ratio") == 1.8
+    assert decision_value(defaults, "canvas", "right_margin") == 0.28
+
+
+def test_smart_defaults_reserve_external_legend_space_for_four_dual_y_series() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=4,
+        row_count=20,
+        x_values=np.arange(20),
+        y_series=[np.arange(20) + index for index in range(4)],
+        x_name="time_s",
+        y_names=["temperature_control_C", "temperature_treated_C"],
+        y2_names=["pressure_control_kPa", "pressure_treated_kPa"],
+    )
+
+    assert decision_value(defaults, "legend", "series_labels") == [
+        "Temperature control",
+        "Temperature treated",
+        "Pressure control",
+        "Pressure treated",
+    ]
+    assert decision_value(defaults, "legend", "position") == "inside_upper_left"
+    assert decision_value(defaults, "legend", "layout", "outside") is False
+    assert decision_value(defaults, "legend", "layout", "candidate_collision_fraction") == 0
+    assert decision_value(defaults, "canvas", "page_width_aspect_ratio") is None
+
+
+def test_smart_defaults_move_dual_y_legend_outside_when_all_corners_are_occupied() -> None:
+    x = np.arange(20)
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=4,
+        row_count=20,
+        x_values=x,
+        y_series=[
+            np.zeros(20),
+            np.ones(20),
+            np.full(20, 100),
+            np.full(20, 200),
+        ],
+        x_name="time_s",
+        y_names=["temperature_low_C", "temperature_high_C"],
+        y2_names=["pressure_low_kPa", "pressure_high_kPa"],
+    )
+
+    assert decision_value(defaults, "legend", "position") == "outside_right"
+    assert decision_value(defaults, "legend", "layout", "outside") is True
+    assert (
+        defaults["legend"]["layout"]["outside"]["reason"]
+        == "all_inside_legend_regions_intersect_data"
+    )
+    assert decision_value(defaults, "canvas", "page_width_aspect_ratio") == 1.8
+
+
+def test_legend_placement_normalizes_dual_y_groups_independently() -> None:
+    x = np.arange(13)
+    placement = recommend_legend_placement(
+        x,
+        [20 + 0.4 * x, 21 + 0.5 * x, 98 + 1.2 * x, 101 + 1.5 * x],
+        labels=[
+            "Temperature control",
+            "Temperature treated",
+            "Pressure control",
+            "Pressure treated",
+        ],
+        group_sizes=[2, 2],
+    )
+
+    assert placement["assessed"] is True
+    assert placement["has_safe_inside"] is True
+    assert placement["position"] == "inside_upper_left"
+    assert placement["collision_fraction"] == 0
+
+
+def test_smart_defaults_rotate_crowded_category_labels() -> None:
+    labels = [f"Long category {index}" for index in range(12)]
+
+    defaults = resolve_visual_defaults(
+        chart_type="bar",
+        series_count=1,
+        row_count=len(labels),
+        x_values=labels,
+        y_series=[np.arange(len(labels))],
+    )
+
+    assert decision_value(defaults, "axes", "x_tick_rotation") == 45
+    assert decision_value(defaults, "axes", "y_zero_baseline") is True
+    assert decision_value(defaults, "canvas", "page_aspect_ratio") == 1.05
+    assert decision_value(defaults, "canvas", "bottom_margin") == 0.25
+
+
+def test_smart_defaults_add_more_height_for_vertical_category_labels() -> None:
+    labels = [f"Exceptionally long category label {index}" for index in range(5)]
+
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=len(labels),
+        x_values=labels,
+        y_series=[np.arange(len(labels))],
+    )
+
+    assert decision_value(defaults, "axes", "x_tick_rotation") == 90
+    assert decision_value(defaults, "canvas", "page_aspect_ratio") == 0.9
+    assert decision_value(defaults, "canvas", "bottom_margin") == 0.35
+
+
+def test_smart_defaults_reduce_dense_scatter_marks() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="scatter",
+        series_count=1,
+        row_count=2500,
+        x_values=np.arange(2500),
+        y_series=[np.arange(2500)],
+    )
+
+    assert decision_value(defaults, "marks", "symbol_size") == 2.5
+    assert decision_value(defaults, "marks", "transparency") == 55.0
+
+
+def test_smart_defaults_use_scientific_notation_for_large_values() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=3,
+        x_values=[1, 2, 3],
+        y_series=[[100_000, 250_000, 500_000]],
+    )
+
+    assert decision_value(defaults, "axes", "y_number_format") == "scientific"
+    assert decision_value(defaults, "axes", "y_decimal_places") == 2


### PR DESCRIPTION
## What changed

- add cross-chart visual defaults for legends, axes, numeric formatting, marker density, categorical label rotation, canvas sizing, heatmaps, and histogram bins
- infer concise axis titles and legend labels from field semantics, units, statistical roles, and tidy `value`/`unit` structures
- improve dual-Y graphs with independent titles, continuous cross-layer palettes, visible right-axis title synchronization, and data-aware legend placement
- rank built-in lcpmgh palettes for white-background readability and hue separation
- document and enforce rebuilding the installed Origin Start/Stop App before real-Origin verification
- add unit, integration, and real-Origin QA coverage for the new behavior

## Why

Origin's previous defaults could concatenate every series into axis titles, repeat units in legends, reuse colors across dual-Y layers, select very pale palettes, clip crowded labels, and place legends over data. The layout logic also treated dual-Y values with different units as one numeric range, so fixed legend thresholds could move a legend outside even when a safe interior region existed.

## Impact

Plots now retain compact semantic labels, use more readable built-in palettes, reserve canvas space only when needed, and place line/scatter legends in the lowest-occupancy interior corner before falling back to an external legend column. Explicit user choices continue to take precedence.

## Validation

- `python.exe -m ruff check src tests`
- `python.exe -m pytest tests -q` — 725 passed
- `git diff --check`
- rebuilt and reinstalled the Origin Start/Stop App
- verified Bridge and Origin connectivity with `doctor --ping-origin`
- inspected real Origin exports for shared units, large legends, dual-Y interior placement, and dual-Y external fallback