### PR TITLE
Add smart axis ticks and grids

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -249,6 +249,17 @@ legends, retains multi-series legends, moves line/scatter legends to the quieter
 upper corner, rotates crowded category ticks, selects scientific notation only
 for extreme magnitudes, keeps nonnegative bar-like charts on a zero baseline,
 and reduces marker size while increasing transparency for dense scatter plots.
+Continuous Cartesian axes request roughly five to seven major ticks according
+to label width and chart footprint, with a single minor subdivision. Datetime
+axes preserve Origin's date labels and use six temporal anchors; categorical
+axes preserve their category positions. Dual-Y plots format the two numeric
+scales independently, then use the smaller shared target tick count so the left
+and right major ticks stay visually aligned. A light horizontal major grid aids
+value comparison on line, scatter, bar, box, and generic Cartesian plots;
+vertical and minor grids remain hidden, and specialized heatmap, surface, and
+polar axes retain their own scale behavior. Standard Cartesian plots keep the
+top frame line but suppress duplicate top-axis major and minor ticks. Long
+numeric tick labels reserve additional left or right page margin automatically.
 Plots with long categorical X labels remain vertically oriented; their page
 height and bottom margin grow automatically so rotated labels are not clipped.
 The height is set from a target page aspect ratio, so repeated formatting does

--- a/src/origin_mcp/client/table_plot.py
+++ b/src/origin_mcp/client/table_plot.py
@@ -1144,10 +1144,17 @@ class _TablePlotMixin(_OriginClientBase):
         """Apply resolved low-risk cross-chart rules to an Origin graph."""
 
         safe_graph = self._escape_labtalk(graph_name)
-        rotation = int(decision_value(defaults, "axes", "x_tick_rotation") or 0)
-        number_format = decision_value(defaults, "axes", "y_number_format")
-        decimal_places = int(decision_value(defaults, "axes", "y_decimal_places"))
-        zero_baseline = bool(decision_value(defaults, "axes", "y_zero_baseline"))
+        axes = defaults.get("axes", {})
+
+        def axis_value(name: str, fallback: Any = None) -> Any:
+            if name not in axes:
+                return fallback
+            return decision_value(axes, name)
+
+        rotation = int(axis_value("x_tick_rotation", 0) or 0)
+        number_format = axis_value("y_number_format", "decimal")
+        decimal_places = int(axis_value("y_decimal_places", -1))
+        zero_baseline = bool(axis_value("y_zero_baseline", False))
         canvas = defaults.get("canvas", {})
         page_aspect_ratio = (
             decision_value(canvas, "page_aspect_ratio") if "page_aspect_ratio" in canvas else None
@@ -1160,6 +1167,7 @@ class _TablePlotMixin(_OriginClientBase):
             if "page_width_aspect_ratio" in canvas
             else None
         )
+        left_margin = decision_value(canvas, "left_margin") if "left_margin" in canvas else None
         right_margin = decision_value(canvas, "right_margin") if "right_margin" in canvas else None
         script_parts = [
             f'win -a "{safe_graph}";',
@@ -1168,17 +1176,76 @@ class _TablePlotMixin(_OriginClientBase):
             f"layer.y.label.numFormat={2 if number_format == 'scientific' else 1};",
             f"layer.y.label.decPlaces={decimal_places};",
         ]
+        top_axis_ticks = axis_value("top_axis_ticks")
+        if top_axis_ticks is not None:
+            script_parts.append(f"layer.x2.ticks={5 if top_axis_ticks else 0};")
+        x_number_format = axis_value("x_number_format")
+        x_decimal_places = axis_value("x_decimal_places")
+        if x_number_format is not None:
+            script_parts.extend(
+                [
+                    f"layer.x.label.numFormat={2 if x_number_format == 'scientific' else 1};",
+                    f"layer.x.label.decPlaces={int(x_decimal_places)};",
+                ]
+            )
+        for axis_name in ("x", "y"):
+            major_ticks = axis_value(f"{axis_name}_major_ticks")
+            minor_ticks = axis_value(f"{axis_name}_minor_ticks")
+            if major_ticks is not None:
+                script_parts.append(f"layer.{axis_name}.majorTicks={int(major_ticks)};")
+            if minor_ticks is not None:
+                script_parts.append(f"layer.{axis_name}.minorTicks={int(minor_ticks)};")
+            major_grid = axis_value(f"{axis_name}_major_grid")
+            if major_grid is not None:
+                script_parts.append(f"layer.{axis_name}.grid.show={1 if major_grid else 0};")
+                if major_grid:
+                    script_parts.extend(
+                        [
+                            f"layer.{axis_name}.grid.majorColor=color(235,235,235);",
+                            f"layer.{axis_name}.grid.majorType=1;",
+                            f"layer.{axis_name}.grid.majorWidth=0.5;",
+                        ]
+                    )
         if zero_baseline:
             script_parts.append("layer.y.from=0;")
+        y2_number_format = axis_value("y2_number_format")
+        if y2_number_format is not None:
+            script_parts.extend(
+                [
+                    "layer -s 2;",
+                    f"layer.y.label.numFormat={2 if y2_number_format == 'scientific' else 1};",
+                    f"layer.y.label.decPlaces={int(axis_value('y2_decimal_places', -1))};",
+                    f"layer.y2.label.numFormat={2 if y2_number_format == 'scientific' else 1};",
+                    f"layer.y2.label.decPlaces={int(axis_value('y2_decimal_places', -1))};",
+                ]
+            )
+            if top_axis_ticks is not None:
+                script_parts.append(f"layer.x2.ticks={5 if top_axis_ticks else 0};")
+            y2_major_ticks = axis_value("y2_major_ticks")
+            y2_minor_ticks = axis_value("y2_minor_ticks")
+            if y2_major_ticks is not None:
+                script_parts.append(f"layer.y.majorTicks={int(y2_major_ticks)};")
+                script_parts.append(f"layer.y2.majorTicks={int(y2_major_ticks)};")
+            if y2_minor_ticks is not None:
+                script_parts.append(f"layer.y.minorTicks={int(y2_minor_ticks)};")
+                script_parts.append(f"layer.y2.minorTicks={int(y2_minor_ticks)};")
+            script_parts.extend(
+                [
+                    "layer.x.grid.show=0;",
+                    f"layer.y.grid.show={1 if axis_value('y2_major_grid', False) else 0};",
+                    f"layer.y2.grid.show={1 if axis_value('y2_major_grid', False) else 0};",
+                ]
+            )
         if page_aspect_ratio is not None or page_width_aspect_ratio is not None:
             script_parts.append("page.kar=0;")
             if page_aspect_ratio is not None:
                 script_parts.append(f"page.height=page.width/{float(page_aspect_ratio):g};")
             elif page_width_aspect_ratio is not None:
                 script_parts.append(f"page.width=page.height*{float(page_width_aspect_ratio):g};")
-        if bottom_margin is not None or right_margin is not None:
+        if bottom_margin is not None or left_margin is not None or right_margin is not None:
             script_parts.append(
-                "page -fls -u -ml 0.08 -mt 0.05 "
+                f"page -fls -u -ml {float(left_margin if left_margin is not None else 0.08):g} "
+                "-mt 0.05 "
                 f"-mr {float(right_margin if right_margin is not None else 0.05):g} "
                 f"-mb {float(bottom_margin if bottom_margin is not None else 0.08):g};"
             )

--- a/src/origin_mcp/visual_defaults.py
+++ b/src/origin_mcp/visual_defaults.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import asdict, dataclass
+from datetime import date, datetime
 from typing import Any
 
 import numpy as np
@@ -26,6 +27,7 @@ class VisualContext:
     series_count: int
     row_count: int
     x_is_categorical: bool
+    x_is_datetime: bool
     x_unique_count: int
     longest_x_label: int
     y_min: float | None
@@ -163,8 +165,45 @@ def resolve_visual_defaults(
         if y2_names_actual or y2_label is not None
         else None
     )
-    y_format, y_decimals = _numeric_format(context.y_min, context.y_max)
-    zero_baseline = context.chart_type == "bar" and (context.y_min is None or context.y_min >= 0)
+    y_split = len(y_names_actual) if y2_names_actual else len(y_series_actual)
+    y_min, y_max = _numeric_extent(y_series_actual[:y_split])
+    y2_min, y2_max = _numeric_extent(y_series_actual[y_split:])
+    x_min, x_max = (
+        (None, None)
+        if context.x_is_categorical or context.x_is_datetime
+        else _numeric_extent([x_values])
+    )
+    x_format, x_decimals = _numeric_format(x_min, x_max)
+    y_format, y_decimals = _numeric_format(y_min, y_max)
+    y2_format, y2_decimals = _numeric_format(y2_min, y2_max)
+    if context.raw_chart_type == "histogram":
+        y_format, y_decimals = "decimal", 0
+    x_major_ticks = _major_tick_target(
+        context,
+        axis="x",
+        number_format=x_format,
+    )
+    y_major_ticks = _major_tick_target(
+        context,
+        axis="y",
+        number_format=y_format,
+    )
+    y2_major_ticks = None
+    if y2_names_actual and y2_min is not None:
+        right_target = _major_tick_target(
+            context,
+            axis="y",
+            number_format=y2_format,
+        )
+        shared_targets = [target for target in (y_major_ticks, right_target) if target is not None]
+        y_major_ticks = min(shared_targets) if shared_targets else None
+        y2_major_ticks = y_major_ticks
+    x_major_grid, y_major_grid = _grid_defaults(context)
+    left_margin = _tick_label_margin(y_min, y_max, y_format, y_decimals)
+    y2_margin = _tick_label_margin(y2_min, y2_max, y2_format, y2_decimals)
+    zero_baseline = context.raw_chart_type == "histogram" or (
+        context.chart_type == "bar" and (y_min is None or y_min >= 0)
+    )
 
     aspect_ratios = {
         "line": 1.5,
@@ -210,8 +249,80 @@ def resolve_visual_defaults(
                 y2_title.source if y2_title is not None else "smart_default",
             ),
             "x_tick_rotation": x_rotation,
+            "x_number_format": _decision(
+                None if _preserve_specialized_x_axis(context) else x_format,
+                (
+                    "preserve_categorical_or_temporal_labels"
+                    if _preserve_specialized_x_axis(context)
+                    else "magnitude_and_range"
+                ),
+            ),
+            "x_decimal_places": _decision(
+                None if _preserve_specialized_x_axis(context) else x_decimals,
+                (
+                    "preserve_categorical_or_temporal_labels"
+                    if _preserve_specialized_x_axis(context)
+                    else "range_appropriate_precision"
+                ),
+            ),
             "y_number_format": _decision(y_format, "magnitude_and_range"),
             "y_decimal_places": _decision(y_decimals, "range_appropriate_precision"),
+            "y2_number_format": _decision(
+                y2_format if y2_min is not None else None,
+                "independent_right_axis_magnitude_and_range"
+                if y2_min is not None
+                else "single_y_axis",
+            ),
+            "y2_decimal_places": _decision(
+                y2_decimals if y2_min is not None else None,
+                "independent_right_axis_precision" if y2_min is not None else "single_y_axis",
+            ),
+            "x_major_ticks": _decision(
+                x_major_ticks,
+                _major_tick_reason(context, axis="x", number_format=x_format),
+            ),
+            "y_major_ticks": _decision(
+                y_major_ticks,
+                _major_tick_reason(context, axis="y", number_format=y_format),
+            ),
+            "y2_major_ticks": _decision(
+                y2_major_ticks,
+                "align_dual_y_major_tick_counts" if y2_major_ticks is not None else "single_y_axis",
+            ),
+            "x_minor_ticks": _decision(
+                _minor_tick_target(context, axis="x"),
+                _minor_tick_reason(context, axis="x"),
+            ),
+            "y_minor_ticks": _decision(
+                _minor_tick_target(context, axis="y"),
+                _minor_tick_reason(context, axis="y"),
+            ),
+            "y2_minor_ticks": _decision(
+                _minor_tick_target(context, axis="y") if y2_major_ticks is not None else None,
+                "match_left_axis_minor_tick_density"
+                if y2_major_ticks is not None
+                else "single_y_axis",
+            ),
+            "x_major_grid": _decision(
+                x_major_grid,
+                "vertical_grid_adds_clutter" if not x_major_grid else "support_x_value_comparison",
+            ),
+            "y_major_grid": _decision(
+                y_major_grid,
+                "support_value_comparison"
+                if y_major_grid
+                else "non_cartesian_or_cell_encoded_chart",
+            ),
+            "y2_major_grid": _decision(False, "avoid_duplicate_dual_y_grid_lines"),
+            "minor_grid": _decision(False, "keep_background_quiet"),
+            "top_axis_ticks": _decision(
+                None if context.chart_type in {"heatmap", "surface", "polar"} else False,
+                (
+                    "preserve_specialized_chart_axis_ticks"
+                    if context.chart_type in {"heatmap", "surface", "polar"}
+                    else "top_frame_does_not_need_duplicate_ticks"
+                ),
+            ),
             "y_zero_baseline": _decision(
                 zero_baseline,
                 "nonnegative_bar_like_chart" if zero_baseline else "preserve_data_range",
@@ -225,7 +336,24 @@ def resolve_visual_defaults(
             "page_aspect_ratio": page_aspect_ratio,
             "bottom_margin": bottom_margin,
             "page_width_aspect_ratio": legend_layout["page_width_aspect_ratio"],
-            "right_margin": legend_layout["right_margin"],
+            "left_margin": _decision(
+                left_margin,
+                "reserve_space_for_long_y_tick_labels"
+                if left_margin is not None
+                else "default_tick_labels_fit",
+            ),
+            "right_margin": _decision(
+                _max_optional(
+                    decision_value(legend_layout, "right_margin"),
+                    y2_margin,
+                ),
+                (
+                    "reserve_external_legend_or_right_axis_tick_space"
+                    if decision_value(legend_layout, "right_margin") is not None
+                    or y2_margin is not None
+                    else "default_tick_labels_fit"
+                ),
+            ),
         },
     }
 
@@ -252,7 +380,7 @@ def _visual_context(
     y_series: list[Any],
 ) -> VisualContext:
     raw_chart_type = str(chart_type or "generic").strip().lower().replace("-", "_")
-    x_is_categorical, x_unique_count, longest_x_label = _x_profile(x_values)
+    x_is_categorical, x_is_datetime, x_unique_count, longest_x_label = _x_profile(x_values)
     y_min, y_max = _numeric_extent(y_series)
     return VisualContext(
         raw_chart_type=raw_chart_type,
@@ -260,6 +388,7 @@ def _visual_context(
         series_count=max(0, int(series_count)),
         row_count=max(0, int(row_count)),
         x_is_categorical=x_is_categorical,
+        x_is_datetime=x_is_datetime,
         x_unique_count=x_unique_count,
         longest_x_label=longest_x_label,
         y_min=y_min,
@@ -267,22 +396,37 @@ def _visual_context(
     )
 
 
-def _x_profile(values: Any) -> tuple[bool, int, int]:
+def _x_profile(values: Any) -> tuple[bool, bool, int, int]:
     if values is None:
-        return False, 0, 0
+        return False, False, 0, 0
     try:
         array = np.asarray(values).reshape(-1)
     except Exception:
-        return False, 0, 0
+        return False, False, 0, 0
     labels = [str(value) for value in array if value is not None and str(value) != "nan"]
     if not labels:
-        return False, 0, 0
+        return False, False, 0, 0
+    is_datetime = _is_datetime_array(array)
+    if is_datetime:
+        return False, True, len(set(labels)), max(len(label) for label in labels)
     try:
         numeric = np.asarray(labels, dtype=float)
         is_categorical = not bool(np.all(np.isfinite(numeric)))
     except (TypeError, ValueError):
         is_categorical = True
-    return is_categorical, len(set(labels)), max(len(label) for label in labels)
+    return is_categorical, False, len(set(labels)), max(len(label) for label in labels)
+
+
+def _is_datetime_array(array: np.ndarray) -> bool:
+    try:
+        if np.issubdtype(array.dtype, np.datetime64):
+            return True
+    except TypeError:
+        pass
+    values = [value for value in array if value is not None]
+    return bool(values) and all(
+        isinstance(value, (date, datetime, np.datetime64)) for value in values
+    )
 
 
 def _numeric_extent(series: list[Any]) -> tuple[float | None, float | None]:
@@ -452,6 +596,105 @@ def _numeric_format(lower: float | None, upper: float | None) -> tuple[str, int]
     approximate_step = span / 5.0
     decimals = max(0, min(6, int(math.ceil(-math.log10(approximate_step)))))
     return "decimal", decimals
+
+
+def _major_tick_target(
+    context: VisualContext,
+    *,
+    axis: str,
+    number_format: str,
+) -> int | None:
+    if context.chart_type in {"heatmap", "surface", "polar"}:
+        return None
+    if axis == "x" and context.x_is_categorical:
+        return None
+    if axis == "x" and context.x_is_datetime:
+        return 6
+    if number_format == "scientific":
+        return 5
+    if axis == "x" and context.chart_type in {"line", "scatter"}:
+        return 7
+    return 6
+
+
+def _major_tick_reason(
+    context: VisualContext,
+    *,
+    axis: str,
+    number_format: str,
+) -> str:
+    if context.chart_type in {"heatmap", "surface", "polar"}:
+        return "preserve_specialized_chart_axis_scale"
+    if axis == "x" and context.x_is_categorical:
+        return "preserve_category_tick_positions"
+    if axis == "x" and context.x_is_datetime:
+        return "six_temporal_anchors"
+    if number_format == "scientific":
+        return "fewer_ticks_for_wide_scientific_labels"
+    if axis == "x" and context.chart_type in {"line", "scatter"}:
+        return "use_wide_canvas_for_seven_x_anchors"
+    return "six_major_ticks_for_readable_comparison"
+
+
+def _preserve_specialized_x_axis(context: VisualContext) -> bool:
+    return (
+        context.x_is_categorical
+        or context.x_is_datetime
+        or context.chart_type
+        in {
+            "heatmap",
+            "surface",
+            "polar",
+        }
+    )
+
+
+def _minor_tick_target(context: VisualContext, *, axis: str) -> int | None:
+    if context.chart_type in {"heatmap", "surface", "polar"}:
+        return None
+    if axis == "x" and (context.x_is_categorical or context.x_is_datetime):
+        return 0
+    return 1
+
+
+def _minor_tick_reason(context: VisualContext, *, axis: str) -> str:
+    if context.chart_type in {"heatmap", "surface", "polar"}:
+        return "preserve_specialized_chart_axis_scale"
+    if axis == "x" and (context.x_is_categorical or context.x_is_datetime):
+        return "avoid_dense_category_or_temporal_subdivisions"
+    return "one_subdivision_between_major_ticks"
+
+
+def _grid_defaults(context: VisualContext) -> tuple[bool, bool]:
+    if context.chart_type in {"heatmap", "surface", "polar"}:
+        return False, False
+    # Horizontal guides make value comparison easier. Vertical guides are
+    # intentionally omitted because they compete with traces, bars and labels.
+    return False, True
+
+
+def _tick_label_margin(
+    lower: float | None,
+    upper: float | None,
+    number_format: str,
+    decimal_places: int,
+) -> float | None:
+    if lower is None or upper is None:
+        return None
+    if number_format == "scientific":
+        return 0.12
+    precision = max(0, decimal_places)
+    longest = max(len(f"{value:.{precision}f}") for value in (lower, upper))
+    if longest >= 10:
+        return 0.12
+    if longest >= 8:
+        return 0.1
+    return None
+
+
+def _max_optional(*values: float | None) -> float | None:
+    present = [value for value in values if value is not None]
+    return max(present) if present else None
 
 
 def automatic_histogram_bin_width(values: Any) -> float | None:

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -1637,6 +1637,70 @@ def test_apply_smart_visual_defaults_widens_canvas_for_external_legend(
     assert legend_calls[0]["position"] == "outside_right"
 
 
+def test_apply_smart_visual_defaults_sets_axis_ticks_grids_and_dual_y_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = OriginClient()
+    scripts = []
+    defaults = {
+        "legend": {"show": {"value": False}},
+        "marks": {
+            "symbol_size": {"value": None},
+            "transparency": {"value": None},
+        },
+        "axes": {
+            "x_tick_rotation": {"value": 0},
+            "x_number_format": {"value": "decimal"},
+            "x_decimal_places": {"value": 0},
+            "y_number_format": {"value": "decimal"},
+            "y_decimal_places": {"value": 1},
+            "y2_number_format": {"value": "scientific"},
+            "y2_decimal_places": {"value": 2},
+            "x_major_ticks": {"value": 7},
+            "y_major_ticks": {"value": 6},
+            "y2_major_ticks": {"value": 6},
+            "x_minor_ticks": {"value": 1},
+            "y_minor_ticks": {"value": 1},
+            "y2_minor_ticks": {"value": 1},
+            "x_major_grid": {"value": False},
+            "y_major_grid": {"value": True},
+            "y2_major_grid": {"value": False},
+            "top_axis_ticks": {"value": False},
+            "y_zero_baseline": {"value": False},
+        },
+        "canvas": {
+            "page_aspect_ratio": {"value": None},
+            "bottom_margin": {"value": None},
+            "page_width_aspect_ratio": {"value": None},
+            "left_margin": {"value": 0.1},
+            "right_margin": {"value": 0.12},
+        },
+    }
+    monkeypatch.setattr(
+        client,
+        "run_labtalk",
+        lambda script: scripts.append(script) or {"result": True},
+    )
+
+    client._apply_smart_visual_defaults(graph_name="Graph1", defaults=defaults)
+
+    script = scripts[0]
+    assert "layer.x.majorTicks=7;" in script
+    assert script.count("layer.x2.ticks=0;") == 2
+    assert "layer.y.majorTicks=6;" in script
+    assert "layer.x.grid.show=0;" in script
+    assert "layer.y.grid.show=1;" in script
+    assert "layer.y.grid.majorColor=color(235,235,235);" in script
+    assert "layer -s 2;" in script
+    assert "layer.y.label.numFormat=2;" in script
+    assert "layer.y2.label.numFormat=2;" in script
+    assert "layer.y2.label.decPlaces=2;" in script
+    assert "layer.y2.majorTicks=6;" in script
+    assert "layer.y.grid.show=0;" in script
+    assert "layer.y2.grid.show=0;" in script
+    assert "page -fls -u -ml 0.1 -mt 0.05 -mr 0.12 -mb 0.08;" in script
+
+
 def test_plot_table_exports_by_graph_name(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_visual_defaults.py
+++ b/tests/test_visual_defaults.py
@@ -237,3 +237,93 @@ def test_smart_defaults_use_scientific_notation_for_large_values() -> None:
 
     assert decision_value(defaults, "axes", "y_number_format") == "scientific"
     assert decision_value(defaults, "axes", "y_decimal_places") == 2
+
+
+def test_smart_defaults_choose_readable_numeric_ticks_and_quiet_grids() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=50,
+        x_values=np.linspace(0, 100, 50),
+        y_series=[np.linspace(0.125, 0.875, 50)],
+    )
+
+    assert decision_value(defaults, "axes", "x_major_ticks") == 7
+    assert decision_value(defaults, "axes", "y_major_ticks") == 6
+    assert decision_value(defaults, "axes", "x_minor_ticks") == 1
+    assert decision_value(defaults, "axes", "y_minor_ticks") == 1
+    assert decision_value(defaults, "axes", "x_major_grid") is False
+    assert decision_value(defaults, "axes", "y_major_grid") is True
+    assert decision_value(defaults, "axes", "minor_grid") is False
+    assert decision_value(defaults, "axes", "top_axis_ticks") is False
+
+
+def test_smart_defaults_format_dual_y_axes_independently_and_align_ticks() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=2,
+        row_count=4,
+        x_values=[0, 1, 2, 3],
+        y_series=[[20.1, 20.2, 20.3, 20.4], [100_000, 200_000, 300_000, 400_000]],
+        y_names=["temperature_C"],
+        y2_names=["pressure_Pa"],
+    )
+
+    assert decision_value(defaults, "axes", "y_number_format") == "decimal"
+    assert decision_value(defaults, "axes", "y2_number_format") == "scientific"
+    assert decision_value(defaults, "axes", "y_major_ticks") == 5
+    assert decision_value(defaults, "axes", "y2_major_ticks") == 5
+    assert decision_value(defaults, "axes", "y2_major_grid") is False
+    assert decision_value(defaults, "canvas", "right_margin") == 0.12
+
+
+def test_smart_defaults_preserve_datetime_labels_with_temporal_tick_density() -> None:
+    dates = np.array(["2026-01-01", "2026-01-02", "2026-01-03"], dtype="datetime64[D]")
+
+    defaults = resolve_visual_defaults(
+        chart_type="line",
+        series_count=1,
+        row_count=3,
+        x_values=dates,
+        y_series=[[1, 2, 3]],
+    )
+
+    assert defaults["context"]["x_is_datetime"] is True
+    assert defaults["context"]["x_is_categorical"] is False
+    assert decision_value(defaults, "axes", "x_tick_rotation") == 0
+    assert decision_value(defaults, "axes", "x_number_format") is None
+    assert decision_value(defaults, "axes", "x_major_ticks") == 6
+    assert decision_value(defaults, "axes", "x_minor_ticks") == 0
+
+
+def test_smart_defaults_leave_specialized_chart_axes_and_grids_untouched() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="heatmap",
+        series_count=1,
+        row_count=9,
+        x_values=np.arange(9),
+        y_series=[np.arange(9)],
+    )
+
+    assert decision_value(defaults, "axes", "x_major_ticks") is None
+    assert decision_value(defaults, "axes", "y_major_ticks") is None
+    assert decision_value(defaults, "axes", "x_minor_ticks") is None
+    assert decision_value(defaults, "axes", "y_minor_ticks") is None
+    assert decision_value(defaults, "axes", "x_number_format") is None
+    assert decision_value(defaults, "axes", "top_axis_ticks") is None
+    assert decision_value(defaults, "axes", "x_major_grid") is False
+    assert decision_value(defaults, "axes", "y_major_grid") is False
+
+
+def test_histogram_count_axis_uses_integer_ticks_and_zero_baseline() -> None:
+    defaults = resolve_visual_defaults(
+        chart_type="histogram",
+        series_count=1,
+        row_count=5,
+        x_values=[-3, -1, 0, 2, 4],
+        y_series=[[-3, -1, 0, 2, 4]],
+    )
+
+    assert decision_value(defaults, "axes", "y_number_format") == "decimal"
+    assert decision_value(defaults, "axes", "y_decimal_places") == 0
+    assert decision_value(defaults, "axes", "y_zero_baseline") is True


### PR DESCRIPTION
## What changed

- add independent X, Y, and dual-Y numeric tick formatting
- choose approximately 5–7 readable major ticks and conservative minor ticks
- align left/right dual-Y major tick counts while preserving independent formats
- show quiet horizontal major grids and hide vertical/minor grids for standard Cartesian charts
- preserve category, datetime, heatmap, surface, and polar axis behavior
- reserve margins for long tick labels and keep histogram/bar zero baselines
- suppress duplicate top-axis major/minor ticks while retaining the top frame
- document the smart-axis rules and add focused unit/integration coverage

## Why

Origin templates can retain dense or duplicated tick marks, including top-axis ticks on ordinary 2D and dual-Y plots. Numeric formatting was also previously applied only to the primary Y axis, so the visible right axis in the doubleY template could keep a different format. These defaults make exported figures quieter, more consistent, and less likely to clip labels.

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy --no-incremental --no-sqlite-cache --no-fixed-format-cache`
- `python -m pytest -q` — 731 passed
- rebuilt and reinstalled the Origin Start/Stop App
- verified live bridge and Origin connectivity with doctor/ping
- exported and visually inspected line, categorical column, and dual-Y figures
- confirmed live dual-Y properties: left/right major ticks aligned, right `y2` scientific formatting applied, only the left horizontal major grid shown, and both top axes use `x2.ticks=0`