### PR TITLE
Harden Origin bridge lifecycle and recovery

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -5,6 +5,7 @@ import json
 import os
 import platform
 import site
+import socket
 import sys
 import sysconfig
 import threading
@@ -65,6 +66,20 @@ def _env_int(name: str, default: int) -> int:
         return int(value)
     except ValueError as exc:
         raise RuntimeError(f"{name} must be an integer, got {value!r}.") from exc
+
+
+def _assert_bridge_port_available(host: str, port: int) -> None:
+    if int(port) == 0:
+        return
+    try:
+        connection = socket.create_connection((host, int(port)), timeout=0.25)
+    except OSError:
+        return
+    connection.close()
+    raise RuntimeError(
+        f"Origin MCP bridge port {host}:{port} is already in use. "
+        "Stop the existing bridge before starting another Origin instance."
+    )
 
 
 def _emit(message: str, fields: dict[str, Any] | None = None) -> None:
@@ -519,6 +534,7 @@ def start_origin_mcp_bridge(
     )
     auto_token_generated = False
     try:
+        _assert_bridge_port_available(host, port)
         # Drop any stale cached origin_mcp modules first -- Origin's Python
         # Console commonly reruns this addon during development -- then resolve
         # src onto sys.path and confirm the bridge import. Clearing before
@@ -526,7 +542,10 @@ def start_origin_mcp_bridge(
         # checkout instead of continuing to serve an older installed copy.
         _clear_origin_mcp_imports()
         package_source = _ensure_origin_mcp_importable(src_dir)
-        from origin_mcp.bridge_handshake import generate_token
+        from origin_mcp.bridge_handshake import generate_generation, generate_token
+
+        generation = generate_generation()
+        lease_id = generation
 
         if token is None and not _env_bool("ORIGIN_MCP_BRIDGE_NO_AUTH", False):
             # Generate a per-session token so the bridge is not reachable by any
@@ -550,7 +569,14 @@ def start_origin_mcp_bridge(
                 raise RuntimeError(_missing_dependency_message(still_missing))
         _emit("loading bridge server", fields={"install_phase": "loading_bridge_server"})
         OriginBridgeServer = _load_bridge_server(install_missing=install_missing)
-        server = OriginBridgeServer((host, port), token=token, max_tasks=max_tasks)
+        server = OriginBridgeServer(
+            (host, port),
+            token=token,
+            max_tasks=max_tasks,
+            generation=generation,
+            lease_id=lease_id,
+            origin_pid=os.getpid(),
+        )
     except Exception as exc:
         _emit(
             "failed to start inside Origin Python",
@@ -581,6 +607,9 @@ def start_origin_mcp_bridge(
                 actual_port,
                 token,
                 status_path=_status_path(),
+                generation=generation,
+                lease_id=lease_id,
+                origin_pid=os.getpid(),
             )
         except Exception as exc:  # pragma: no cover - defensive
             _emit(
@@ -620,6 +649,9 @@ def start_origin_mcp_bridge(
         "max_tasks": max_tasks,
         "background": background,
         "auth_enabled": auth_enabled,
+        "generation": generation,
+        "lease_id": lease_id,
+        "origin_pid": os.getpid(),
     }
     _notify(
         "Bridge is running inside Origin.",
@@ -631,6 +663,9 @@ def start_origin_mcp_bridge(
             "background": background,
             "running": True,
             "auth_enabled": auth_enabled,
+            "generation": generation,
+            "lease_id": lease_id,
+            "origin_pid": os.getpid(),
             "handshake_path": str(handshake_path) if handshake_path else None,
             "install_phase": "running",
             "last_successful_start": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/scripts/build_origin_app.py
+++ b/scripts/build_origin_app.py
@@ -196,13 +196,16 @@ try {
     $reader = [System.IO.StreamReader]::new($stream, $utf8)
 
     $request = @{
-        id = "origin-mcp-stop-button"
+        id = "origin-mcp-stop-button-" + [System.Guid]::NewGuid().ToString("N")
         method = "shutdown"
         params = @{
             release_origin = $true
             close_origin = $false
         }
         token = [string]$handshake.token
+        client_id = "origin-mcp-stop-app"
+        generation = [string]$handshake.generation
+        lease_id = [string]$handshake.lease_id
     }
     $writer.WriteLine(($request | ConvertTo-Json -Compress -Depth 5))
     $raw = $reader.ReadLine()

--- a/src/origin_mcp/_bridge_server.py
+++ b/src/origin_mcp/_bridge_server.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from . import __version__
 from ._bridge_dispatch import TASKABLE_METHODS, call_client_method, call_origin_method
@@ -189,9 +189,14 @@ class _OriginBridgeServerState(_StateBase):
         self.request_replay = _RequestReplayCache()
 
     def server_bind(self) -> None:
+        tcp_server = cast(socketserver.TCPServer, self)
         if os.name == "nt" and hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
-            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-        super().server_bind()
+            tcp_server.socket.setsockopt(
+                socket.SOL_SOCKET,
+                socket.SO_EXCLUSIVEADDRUSE,
+                1,
+            )
+        socketserver.TCPServer.server_bind(tcp_server)
 
     def request_shutdown(self) -> None:
         self.shutdown_requested.set()

--- a/src/origin_mcp/_bridge_server.py
+++ b/src/origin_mcp/_bridge_server.py
@@ -5,6 +5,7 @@ import importlib
 import ipaddress
 import json
 import os
+import socket
 import socketserver
 import threading
 import time
@@ -169,8 +170,14 @@ class _OriginBridgeServerState(_StateBase):
         token: str | None = None,
         client: OriginClient | None = None,
         max_tasks: int = DEFAULT_MAX_TASKS,
+        generation: str | None = None,
+        lease_id: str | None = None,
+        origin_pid: int | None = None,
     ) -> None:
         self.token = token
+        self.generation = generation
+        self.lease_id = lease_id
+        self.origin_pid = os.getpid() if origin_pid is None else int(origin_pid)
         self.client = client or OriginClient()
         self.tasks = BridgeTaskManager(
             self.client,
@@ -180,6 +187,11 @@ class _OriginBridgeServerState(_StateBase):
         self.max_tasks = max(1, max_tasks)
         self.shutdown_requested = threading.Event()
         self.request_replay = _RequestReplayCache()
+
+    def server_bind(self) -> None:
+        if os.name == "nt" and hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        super().server_bind()
 
     def request_shutdown(self) -> None:
         self.shutdown_requested.set()
@@ -210,7 +222,7 @@ class _OriginBridgeServerState(_StateBase):
 
 
 class OriginBridgeServer(_OriginBridgeServerState, socketserver.ThreadingTCPServer):
-    allow_reuse_address = True
+    allow_reuse_address = False
     daemon_threads = True
     persistent_connections = True
 
@@ -220,14 +232,24 @@ class OriginBridgeServer(_OriginBridgeServerState, socketserver.ThreadingTCPServ
         token: str | None = None,
         client: OriginClient | None = None,
         max_tasks: int = DEFAULT_MAX_TASKS,
+        generation: str | None = None,
+        lease_id: str | None = None,
+        origin_pid: int | None = None,
     ) -> None:
         validate_bridge_host(server_address[0])
         super().__init__(server_address, OriginBridgeHandler)
-        self._init_bridge_state(token=token, client=client, max_tasks=max_tasks)
+        self._init_bridge_state(
+            token=token,
+            client=client,
+            max_tasks=max_tasks,
+            generation=generation,
+            lease_id=lease_id,
+            origin_pid=origin_pid,
+        )
 
 
 class OriginEmbeddedBridgeServer(_OriginBridgeServerState, socketserver.TCPServer):
-    allow_reuse_address = True
+    allow_reuse_address = False
     # The embedded server is polled cooperatively from Origin's UI thread via
     # handle_request(); each handler invocation must service one request and
     # return so the message pump keeps running.
@@ -242,10 +264,20 @@ class OriginEmbeddedBridgeServer(_OriginBridgeServerState, socketserver.TCPServe
         token: str | None = None,
         client: OriginClient | None = None,
         max_tasks: int = DEFAULT_MAX_TASKS,
+        generation: str | None = None,
+        lease_id: str | None = None,
+        origin_pid: int | None = None,
     ) -> None:
         validate_bridge_host(server_address[0])
         super().__init__(server_address, OriginBridgeHandler)
-        self._init_bridge_state(token=token, client=client, max_tasks=max_tasks)
+        self._init_bridge_state(
+            token=token,
+            client=client,
+            max_tasks=max_tasks,
+            generation=generation,
+            lease_id=lease_id,
+            origin_pid=origin_pid,
+        )
 
 
 class OriginBridgeHandler(socketserver.StreamRequestHandler):
@@ -317,6 +349,26 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
                     "Invalid Origin bridge token.",
                     error_code="origin_bridge_unauthorized",
                 )
+        supplied_generation = request.get("generation")
+        if (
+            self.server.generation
+            and supplied_generation
+            and not hmac.compare_digest(str(supplied_generation), self.server.generation)
+        ):
+            raise OriginOperationError(
+                "Origin bridge generation changed; refresh the bridge handshake.",
+                error_code="origin_bridge_generation_mismatch",
+            )
+        supplied_lease_id = request.get("lease_id")
+        if (
+            self.server.lease_id
+            and supplied_lease_id
+            and not hmac.compare_digest(str(supplied_lease_id), self.server.lease_id)
+        ):
+            raise OriginOperationError(
+                "Origin bridge lease changed; refresh the bridge handshake.",
+                error_code="origin_bridge_generation_mismatch",
+            )
         method = request.get("method")
         params = request.get("params") or {}
         if not isinstance(method, str) or not method:
@@ -331,6 +383,9 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             return {
                 "bridge": "origin-mcp-bridge",
                 "version": __version__,
+                "generation": self.server.generation,
+                "lease_id": self.server.lease_id,
+                "origin_pid": self.server.origin_pid,
                 "runtime": python_runtime_profile().as_dict(),
                 "taskable_methods": sorted(TASKABLE_METHODS),
                 "max_tasks": self.server.max_tasks,
@@ -401,11 +456,13 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
         release_origin = bool(params.get("release_origin", True))
         close_origin = bool(params.get("close_origin", False))
         external = self._bridge_is_external_origin()
+        embedded = not self.server.tasks_use_worker_thread
         result: dict[str, Any] = {
             "shutdown_requested": True,
             "release_origin": release_origin,
             "close_origin": close_origin,
             "external_origin": external,
+            "embedded_origin": embedded,
         }
         if release_origin:
             # In external mode the bridge drives a SEPARATE spawned Origin holding
@@ -415,6 +472,11 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             # Opt out of the external auto-close with ORIGIN_MCP_KEEP_EXTERNAL=1.
             close_spawned = close_origin or (external and not _keep_external_origin())
             release_method = "force_quit" if close_spawned else "detach"
+            if embedded and not close_origin:
+                result["origin_release"] = {"preserved": True, "closed": False}
+                result["origin_release_method"] = "embedded_noop"
+                self.server.request_shutdown()
+                return result
             release = getattr(self.server.client, release_method, None)
             if callable(release):
                 try:

--- a/src/origin_mcp/app_installer.py
+++ b/src/origin_mcp/app_installer.py
@@ -118,10 +118,13 @@ try {
     $writer.AutoFlush = $true
     $reader = [System.IO.StreamReader]::new($stream, $utf8)
     $request = @{
-        id = "origin-mcp-stop-button"
+        id = "origin-mcp-stop-button-" + [System.Guid]::NewGuid().ToString("N")
         method = "shutdown"
         params = @{ release_origin = $true; close_origin = $false }
         token = [string]$handshake.token
+        client_id = "origin-mcp-stop-app"
+        generation = [string]$handshake.generation
+        lease_id = [string]$handshake.lease_id
     }
     $writer.WriteLine(($request | ConvertTo-Json -Compress -Depth 5))
     $raw = $reader.ReadLine()

--- a/src/origin_mcp/bridge_client.py
+++ b/src/origin_mcp/bridge_client.py
@@ -140,14 +140,26 @@ class OriginBridgeConfig:
             )
         )
 
+        handshake_host = handshake.get("host")
+        handshake_port = _optional_int(handshake.get("port"))
+        handshake_token = handshake.get("token")
+        handshake_matches_connection = (
+            isinstance(handshake_host, str)
+            and handshake_host == resolved_host
+            and handshake_port == resolved_port
+            and isinstance(handshake_token, str)
+            and handshake_token == resolved_token
+        )
+        lifecycle = handshake if handshake_matches_connection else {}
+
         return cls(
             host=resolved_host,
             port=resolved_port,
             token=resolved_token,
             timeout=resolved_timeout,
-            generation=_optional_string(handshake.get("generation")),
-            lease_id=_optional_string(handshake.get("lease_id")),
-            origin_pid=_optional_int(handshake.get("origin_pid") or handshake.get("pid")),
+            generation=_optional_string(lifecycle.get("generation")),
+            lease_id=_optional_string(lifecycle.get("lease_id")),
+            origin_pid=_optional_int(lifecycle.get("origin_pid") or lifecycle.get("pid")),
             handshake_managed=handshake_managed,
         )
 
@@ -177,6 +189,7 @@ class OriginBridgeClient:
                     or not self.config.handshake_managed
                     or exc.error_code
                     not in {
+                        "origin_bridge_unavailable",
                         "origin_bridge_unauthorized",
                         "origin_bridge_generation_mismatch",
                     }

--- a/src/origin_mcp/bridge_client.py
+++ b/src/origin_mcp/bridge_client.py
@@ -55,12 +55,27 @@ def _parse_bridge_timeout(value: Any, source: str) -> float:
     return timeout
 
 
+def _optional_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass(frozen=True)
 class OriginBridgeConfig:
     host: str = DEFAULT_BRIDGE_HOST
     port: int = DEFAULT_BRIDGE_PORT
     token: str | None = None
     timeout: float = DEFAULT_BRIDGE_TIMEOUT
+    generation: str | None = None
+    lease_id: str | None = None
+    origin_pid: int | None = None
+    handshake_managed: bool = False
 
     def __post_init__(self) -> None:
         if not str(self.host).strip():
@@ -107,11 +122,14 @@ class OriginBridgeConfig:
 
         if token is not None:
             resolved_token: str | None = token
+            handshake_managed = False
         elif "ORIGIN_MCP_BRIDGE_TOKEN" in env:
             resolved_token = env["ORIGIN_MCP_BRIDGE_TOKEN"] or None
+            handshake_managed = False
         else:
             handshake_token = handshake.get("token")
             resolved_token = handshake_token if isinstance(handshake_token, str) else None
+            handshake_managed = True
 
         resolved_timeout = (
             timeout
@@ -127,6 +145,10 @@ class OriginBridgeConfig:
             port=resolved_port,
             token=resolved_token,
             timeout=resolved_timeout,
+            generation=_optional_string(handshake.get("generation")),
+            lease_id=_optional_string(handshake.get("lease_id")),
+            origin_pid=_optional_int(handshake.get("origin_pid") or handshake.get("pid")),
+            handshake_managed=handshake_managed,
         )
 
 
@@ -140,19 +162,51 @@ class OriginBridgeClient:
 
     def __init__(self, config: OriginBridgeConfig | None = None) -> None:
         self.config = config or OriginBridgeConfig.from_env()
+        self.client_id = str(uuid.uuid4())
         self._lock = threading.Lock()
         self._socket: socket.socket | None = None
         self._stream: Any = None
 
     def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        for refresh_attempt in (0, 1):
+            try:
+                return self._request_once(method, params)
+            except OriginBridgeError as exc:
+                if (
+                    refresh_attempt
+                    or not self.config.handshake_managed
+                    or exc.error_code
+                    not in {
+                        "origin_bridge_unauthorized",
+                        "origin_bridge_generation_mismatch",
+                    }
+                ):
+                    raise
+                refreshed = OriginBridgeConfig.from_env(timeout=self.config.timeout)
+                if refreshed == self.config:
+                    raise
+                self.close()
+                self.config = refreshed
+        raise OriginBridgeError("Origin bridge authentication refresh failed.")
+
+    def _request_once(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         request_id = str(uuid.uuid4())
         payload: dict[str, Any] = {
             "id": request_id,
             "method": method,
             "params": _bridge_json_safe(params or {}),
+            "client_id": self.client_id,
         }
         if self.config.token:
             payload["token"] = self.config.token
+        if self.config.generation:
+            payload["generation"] = self.config.generation
+        if self.config.lease_id:
+            payload["lease_id"] = self.config.lease_id
         encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
 
         with self._lock:

--- a/src/origin_mcp/bridge_handshake.py
+++ b/src/origin_mcp/bridge_handshake.py
@@ -47,6 +47,12 @@ def generate_token() -> str:
     return secrets.token_urlsafe(32)
 
 
+def generate_generation() -> str:
+    """Return a fresh bridge generation identifier."""
+
+    return secrets.token_urlsafe(16)
+
+
 def write_handshake(
     host: str,
     port: int,
@@ -54,6 +60,9 @@ def write_handshake(
     *,
     path: Path | None = None,
     status_path: Path | None = None,
+    generation: str | None = None,
+    lease_id: str | None = None,
+    origin_pid: int | None = None,
 ) -> Path:
     """Atomically write the bridge handshake file and return its path.
 
@@ -64,12 +73,18 @@ def write_handshake(
 
     target = path or default_handshake_path()
     target.parent.mkdir(parents=True, exist_ok=True)
+    resolved_generation = generation or generate_generation()
+    resolved_lease_id = lease_id or resolved_generation
+    resolved_origin_pid = os.getpid() if origin_pid is None else int(origin_pid)
     payload: dict[str, Any] = {
-        "handshake_version": 1,
+        "handshake_version": 2,
         "host": host,
         "port": int(port),
         "token": token,
-        "pid": os.getpid(),
+        "pid": resolved_origin_pid,
+        "origin_pid": resolved_origin_pid,
+        "generation": resolved_generation,
+        "lease_id": resolved_lease_id,
         "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
     if status_path is not None:

--- a/src/origin_mcp/client/base.py
+++ b/src/origin_mcp/client/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 import threading
 from pathlib import Path
 from typing import Any
@@ -64,6 +65,49 @@ ANALYSIS_XY_OUTPUTS = {"polynomial_fit", "smooth", "interpolate", "normalize"}
 _MIN_TRUNCATION_PREFIX_LEN = 12
 
 
+def _embedded_origin_api() -> Any | None:
+    """Expose Origin's embedded API under the name expected by originpro.
+
+    Origin 2026 can provide the host API as ``_PyOrigin`` while originpro still
+    imports ``PyOrigin``. Without the alias, originpro falls back to OriginExt;
+    its first real API call then starts a separate ``Origin64.exe -Embedding``
+    process even though the bridge is already running inside Origin.
+    """
+
+    try:
+        return importlib.import_module("PyOrigin")
+    except ImportError:
+        try:
+            embedded = importlib.import_module("_PyOrigin")
+        except ImportError:
+            return None
+        sys.modules["PyOrigin"] = embedded
+        return embedded
+
+
+def _load_originpro() -> Any:
+    embedded = _embedded_origin_api()
+    cached_config = sys.modules.get("originpro.config")
+    if embedded is not None and bool(getattr(cached_config, "oext", False)):
+        # A previous bridge generation may already have imported originpro via
+        # its OriginExt fallback. Drop that package generation after installing
+        # the PyOrigin alias so the next import binds to the host process.
+        for name in tuple(sys.modules):
+            if name == "originpro" or name.startswith("originpro."):
+                sys.modules.pop(name, None)
+
+    op = importlib.import_module("originpro")
+    if embedded is not None:
+        config = importlib.import_module("originpro.config")
+        if bool(getattr(config, "oext", False)):
+            raise OriginDependencyError(
+                "Origin's embedded Python could not bind originpro to PyOrigin. "
+                "Refusing to fall back to OriginExt because that would start a separate "
+                "Origin automation process."
+            )
+    return op
+
+
 class _OriginClientBase:
     """Shared state and helpers for OriginClient mixins."""
 
@@ -83,7 +127,9 @@ class _OriginClientBase:
     def op(self) -> Any:
         if self._op is None:
             try:
-                self._op = importlib.import_module("originpro")
+                self._op = _load_originpro()
+            except OriginDependencyError:
+                raise
             except ImportError as exc:
                 raise OriginDependencyError(
                     "The 'originpro' package is not available. Install Origin/OriginPro and "

--- a/src/origin_mcp/recovery.py
+++ b/src/origin_mcp/recovery.py
@@ -35,6 +35,13 @@ _BRIDGE_GUIDANCE: dict[str, RecoveryGuidance] = {
             "Match ORIGIN_MCP_BRIDGE_TOKEN to the active handshake, then run `origin-mcp doctor`.",
         ),
     ),
+    "origin_bridge_generation_mismatch": RecoveryGuidance(
+        True,
+        (
+            "Reload the active bridge handshake and reconnect the MCP client.",
+            "Confirm only one Origin process listens on the configured bridge port.",
+        ),
+    ),
     "invalid_bridge_config": RecoveryGuidance(
         True,
         (

--- a/src/origin_mcp/tools/_shared.py
+++ b/src/origin_mcp/tools/_shared.py
@@ -195,6 +195,7 @@ DATA_TOOL_NAMES = COMPACT_TOOL_NAMES | frozenset(
         "origin_connect_selection",
         "origin_disconnect_connector",
         "origin_refresh_all_connectors",
+        "origin_export_worksheet_csv",
         "origin_create_matrix",
         "origin_get_matrix_info",
         "origin_read_matrix",

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -57,6 +57,19 @@ def test_addon_can_disable_dependency_install(monkeypatch) -> None:
     assert addon._env_bool("ORIGIN_MCP_INSTALL_MISSING", True) is False
 
 
+def test_addon_rejects_an_occupied_bridge_port() -> None:
+    addon = load_addon_module()
+    listener = addon.socket.socket(addon.socket.AF_INET, addon.socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    try:
+        host, port = listener.getsockname()
+        with pytest.raises(RuntimeError, match="already in use"):
+            addon._assert_bridge_port_available(host, port)
+    finally:
+        listener.close()
+
+
 def test_addon_auto_detects_adjacent_src(monkeypatch) -> None:
     addon = load_addon_module()
     monkeypatch.delenv("ORIGIN_MCP_SRC", raising=False)
@@ -228,6 +241,7 @@ def test_start_records_runtime_probe_before_import_fail(monkeypatch) -> None:
     }
 
     monkeypatch.setattr(addon, "_origin_runtime_probe", lambda: probe)
+    monkeypatch.setattr(addon, "_assert_bridge_port_available", lambda *_args: None)
     monkeypatch.setattr(
         addon,
         "_emit",
@@ -277,6 +291,7 @@ def test_start_records_successful_start_diagnostics(monkeypatch) -> None:
         addon, "_notify", lambda message, fields=None: emitted.append((message, fields))
     )
     monkeypatch.setattr(addon, "_clear_origin_mcp_imports", lambda: None)
+    monkeypatch.setattr(addon, "_assert_bridge_port_available", lambda *_args: None)
     monkeypatch.setattr(addon, "_ensure_origin_mcp_importable", lambda _src=None: "source")
     monkeypatch.setattr(addon, "_install_missing_runtime_packages", lambda: None)
     monkeypatch.setattr(addon, "_load_bridge_server", lambda install_missing=True: FakeServer)
@@ -319,13 +334,14 @@ def test_start_aborts_when_generated_token_cannot_be_published(monkeypatch) -> N
     monkeypatch.setattr(addon, "_emit", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(addon, "_notify", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(addon, "_clear_origin_mcp_imports", lambda: None)
+    monkeypatch.setattr(addon, "_assert_bridge_port_available", lambda *_args: None)
     monkeypatch.setattr(addon, "_ensure_origin_mcp_importable", lambda _src=None: "source")
     monkeypatch.setattr(addon, "_missing_runtime_packages", lambda: [])
     monkeypatch.setattr(addon, "_load_bridge_server", lambda install_missing=True: make_server)
     monkeypatch.setattr(
         bridge_handshake,
         "write_handshake",
-        lambda *_args: (_ for _ in ()).throw(OSError("read-only temp")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("read-only temp")),
     )
 
     with pytest.raises(RuntimeError, match="automatically generated"):

--- a/tests/test_app_installer.py
+++ b/tests/test_app_installer.py
@@ -25,6 +25,9 @@ def test_installer_creates_self_contained_origin_apps(tmp_path: Path) -> None:
     stop_script = (stop / "stop_bridge.ps1").read_text(encoding="utf-8")
     assert "$env:ORIGIN_MCP_BRIDGE_HANDSHAKE" in stop_script
     assert "GetTempPath" in stop_script
+    assert "[System.Guid]::NewGuid()" in stop_script
+    assert 'id = "origin-mcp-stop-button-" +' in stop_script
+    assert "generation = [string]$handshake.generation" in stop_script
     assets = Path(__file__).resolve().parents[1] / "docs" / "assets"
     assert (start / "AppIcon.png").read_bytes() == (
         assets / "origin-mcp-start-icon.png"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -372,6 +372,45 @@ def test_bridge_rejects_request_id_reuse_with_different_content() -> None:
     assert responses[1]["error_code"] == "bridge_request_id_conflict"
 
 
+def test_bridge_rejects_stale_generation() -> None:
+    server = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token="shared-token",
+        generation="current-generation",
+        lease_id="current-generation",
+        client=FakeOriginClient(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        config = OriginBridgeConfig(
+            host=host,
+            port=port,
+            token="shared-token",
+            timeout=2.0,
+            generation="stale-generation",
+            lease_id="stale-generation",
+        )
+        with pytest.raises(OriginBridgeError) as excinfo:
+            OriginBridgeClient(config).request("ping")
+        assert excinfo.value.error_code == "origin_bridge_generation_mismatch"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_bridge_port_cannot_be_bound_twice() -> None:
+    first = OriginBridgeServer(("127.0.0.1", 0), client=FakeOriginClient())
+    try:
+        host, port = first.server_address
+        with pytest.raises(OSError):
+            OriginBridgeServer((host, port), client=FakeOriginClient())
+    finally:
+        first.server_close()
+
+
 def test_embedded_bridge_server_handles_request_without_handler_threads() -> None:
     server = OriginEmbeddedBridgeServer(
         ("127.0.0.1", 0),
@@ -703,7 +742,29 @@ def test_bridge_shutdown_can_keep_origin_alive() -> None:
         "release_origin": False,
         "close_origin": False,
         "external_origin": False,
+        "embedded_origin": False,
     }
+
+
+def test_embedded_bridge_shutdown_preserves_host_origin() -> None:
+    fake_client = FakeOriginClient()
+    server = OriginEmbeddedBridgeServer(
+        ("127.0.0.1", 0),
+        client=fake_client,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = bridge_client(server).request("shutdown")
+        thread.join(timeout=2)
+    finally:
+        server.server_close()
+
+    assert result["embedded_origin"] is True
+    assert result["origin_release_method"] == "embedded_noop"
+    assert result["origin_release"] == {"preserved": True, "closed": False}
+    assert fake_client.detached is False
+    assert fake_client.force_closed is False
 
 
 def test_bridge_shutdown_closes_spawned_external_origin() -> None:

--- a/tests/test_bridge_handshake.py
+++ b/tests/test_bridge_handshake.py
@@ -113,6 +113,48 @@ def test_from_env_explicit_arg_overrides_everything(
 
     assert config.token == "explicit-token"
     assert config.port == 12345
+    assert config.generation is None
+    assert config.lease_id is None
+    assert config.origin_pid is None
+    assert config.handshake_managed is False
+
+
+def test_explicit_connection_ignores_unrelated_handshake_lifecycle(
+    isolated_handshake: Path,
+) -> None:
+    bridge_handshake.write_handshake(
+        "127.0.0.1",
+        50000,
+        "stale-token",
+        generation="stale-generation",
+        lease_id="stale-generation",
+    )
+    server = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token="live-token",
+        generation="live-generation",
+        lease_id="live-generation",
+        client=FakeOriginClient(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        config = OriginBridgeConfig.from_env(
+            host=host,
+            port=port,
+            token="live-token",
+            timeout=2.0,
+        )
+
+        assert config.generation is None
+        assert config.lease_id is None
+        result = OriginBridgeClient(config).request("ping")
+        assert result["generation"] == "live-generation"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 def test_from_env_falls_back_to_defaults_without_handshake(isolated_handshake: Path) -> None:
@@ -248,6 +290,64 @@ def test_handshake_managed_client_refreshes_rotated_token(
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_handshake_managed_client_refreshes_moved_endpoint(
+    isolated_handshake: Path,
+) -> None:
+    first = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token="token-one",
+        generation="generation-one",
+        lease_id="generation-one",
+        client=FakeOriginClient(),
+    )
+    first_thread = threading.Thread(target=first.serve_forever, daemon=True)
+    first_thread.start()
+    second = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token="token-two",
+        generation="generation-two",
+        lease_id="generation-two",
+        client=FakeOriginClient(),
+    )
+    second_thread = threading.Thread(target=second.serve_forever, daemon=True)
+    second_thread.start()
+    try:
+        first_host, first_port = first.server_address
+        second_host, second_port = second.server_address
+        assert first_port != second_port
+        bridge_handshake.write_handshake(
+            first_host,
+            first_port,
+            "token-one",
+            generation="generation-one",
+            lease_id="generation-one",
+        )
+        client = OriginBridgeClient(OriginBridgeConfig.from_env(timeout=0.25))
+
+        bridge_handshake.write_handshake(
+            second_host,
+            second_port,
+            "token-two",
+            generation="generation-two",
+            lease_id="generation-two",
+        )
+        first.shutdown()
+        first.server_close()
+        first_thread.join(timeout=2)
+
+        result = client.request("ping")
+        assert result["generation"] == "generation-two"
+        assert client.config.port == second_port
+        assert client.config.token == "token-two"
+    finally:
+        first.shutdown()
+        first.server_close()
+        first_thread.join(timeout=2)
+        second.shutdown()
+        second.server_close()
+        second_thread.join(timeout=2)
 
 
 def test_bridge_clients_have_distinct_client_ids() -> None:

--- a/tests/test_bridge_handshake.py
+++ b/tests/test_bridge_handshake.py
@@ -60,6 +60,10 @@ def test_write_read_clear_roundtrip(isolated_handshake: Path) -> None:
     assert data["host"] == "127.0.0.1"
     assert data["port"] == 47631
     assert data["token"] == "tok-123"
+    assert data["handshake_version"] == 2
+    assert data["generation"]
+    assert data["lease_id"] == data["generation"]
+    assert data["origin_pid"] == data["pid"]
     assert data["status_path"] == str(status_path.resolve())
     assert bridge_handshake.read_handshake_token() == "tok-123"
 
@@ -201,3 +205,51 @@ def test_handshake_token_authenticates_against_running_bridge(isolated_handshake
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_handshake_managed_client_refreshes_rotated_token(
+    isolated_handshake: Path,
+) -> None:
+    server = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token="token-one",
+        generation="generation-one",
+        lease_id="generation-one",
+        client=FakeOriginClient(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        bridge_handshake.write_handshake(
+            host,
+            port,
+            "token-one",
+            generation="generation-one",
+            lease_id="generation-one",
+        )
+        client = OriginBridgeClient(OriginBridgeConfig.from_env(timeout=2.0))
+
+        server.token = "token-two"
+        server.generation = "generation-two"
+        server.lease_id = "generation-two"
+        bridge_handshake.write_handshake(
+            host,
+            port,
+            "token-two",
+            generation="generation-two",
+            lease_id="generation-two",
+        )
+
+        result = client.request("ping")
+        assert result["generation"] == "generation-two"
+        assert client.config.token == "token-two"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_bridge_clients_have_distinct_client_ids() -> None:
+    config = OriginBridgeConfig()
+    assert OriginBridgeClient(config).client_id != OriginBridgeClient(config).client_id

--- a/tests/test_origin_app_packaging.py
+++ b/tests/test_origin_app_packaging.py
@@ -97,6 +97,8 @@ def test_build_origin_app_sources() -> None:
     assert "close_origin = $false" in stop_powershell
     assert "Bridge stop requested." in stop_powershell
     assert "$env:ORIGIN_MCP_BRIDGE_HANDSHAKE" in stop_powershell
+    assert "[System.Guid]::NewGuid()" in stop_powershell
+    assert 'id = "origin-mcp-stop-button-" +' in stop_powershell
 
     stop_vbs = (stop_app_dir / "stop_bridge.vbs").read_text(encoding="utf-8")
     assert "WScript.Shell" in stop_vbs

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -1,8 +1,10 @@
 import math
 import os
 import struct
+import sys
 import zlib
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pandas as pd
@@ -16,9 +18,117 @@ from origin_mcp.chart_palette import (
     palette_catalog,
     select_palette_for_count,
 )
+from origin_mcp.client import base as client_base
 from origin_mcp.compat import PLOT_TYPE_CATALOG
-from origin_mcp.errors import OriginOperationError
+from origin_mcp.errors import OriginDependencyError, OriginOperationError
 from origin_mcp.origin_client import GraphRef, OriginClient, WorksheetRef
+
+
+def test_origin_client_aliases_embedded_api_before_importing_originpro(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedded = SimpleNamespace(name="embedded-pyorigin")
+    originpro = SimpleNamespace(name="originpro")
+    config = SimpleNamespace(oext=False)
+    imports: list[str] = []
+
+    def fake_import(name: str) -> Any:
+        imports.append(name)
+        if name == "PyOrigin":
+            raise ModuleNotFoundError("No module named 'PyOrigin'", name="PyOrigin")
+        if name == "_PyOrigin":
+            return embedded
+        if name == "originpro":
+            assert sys.modules["PyOrigin"] is embedded
+            return originpro
+        if name == "originpro.config":
+            return config
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
+    try:
+        assert OriginClient().op is originpro
+    finally:
+        sys.modules.pop("PyOrigin", None)
+
+    assert imports == ["PyOrigin", "_PyOrigin", "originpro", "originpro.config"]
+
+
+def test_origin_client_reloads_cached_originext_after_embedded_api_appears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedded = SimpleNamespace(name="embedded-pyorigin")
+    stale_originpro = SimpleNamespace(name="stale-originpro")
+    stale_config = SimpleNamespace(oext=True)
+    fresh_originpro = SimpleNamespace(name="fresh-originpro")
+    fresh_config = SimpleNamespace(oext=False)
+    monkeypatch.setitem(sys.modules, "originpro", stale_originpro)
+    monkeypatch.setitem(sys.modules, "originpro.config", stale_config)
+
+    def fake_import(name: str) -> Any:
+        if name == "PyOrigin":
+            raise ModuleNotFoundError("No module named 'PyOrigin'", name="PyOrigin")
+        if name == "_PyOrigin":
+            return embedded
+        if name == "originpro":
+            assert "originpro" not in sys.modules
+            assert "originpro.config" not in sys.modules
+            return fresh_originpro
+        if name == "originpro.config":
+            return fresh_config
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
+    try:
+        assert OriginClient().op is fresh_originpro
+    finally:
+        sys.modules.pop("PyOrigin", None)
+
+
+def test_origin_client_refuses_originext_fallback_inside_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedded = SimpleNamespace(name="embedded-pyorigin")
+    originpro = SimpleNamespace(name="originpro")
+    config = SimpleNamespace(oext=True)
+
+    def fake_import(name: str) -> Any:
+        if name == "PyOrigin":
+            raise ModuleNotFoundError("No module named 'PyOrigin'", name="PyOrigin")
+        if name == "_PyOrigin":
+            return embedded
+        if name == "originpro":
+            return originpro
+        if name == "originpro.config":
+            return config
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
+    try:
+        with pytest.raises(OriginDependencyError, match="Refusing to fall back to OriginExt"):
+            _ = OriginClient().op
+    finally:
+        sys.modules.pop("PyOrigin", None)
+
+
+def test_origin_client_keeps_originext_available_outside_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    originpro = SimpleNamespace(name="external-originpro")
+    imports: list[str] = []
+
+    def fake_import(name: str) -> Any:
+        imports.append(name)
+        if name in {"PyOrigin", "_PyOrigin"}:
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        if name == "originpro":
+            return originpro
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
+
+    assert OriginClient().op is originpro
+    assert imports == ["PyOrigin", "_PyOrigin", "originpro"]
 
 
 def test_read_table_csv(tmp_path: Path) -> None:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -11,6 +11,7 @@ from origin_mcp.recovery import recovery_guidance
         ("origin_bridge_unavailable", True, "Start App"),
         ("origin_bridge_timeout", True, "modal dialog"),
         ("origin_bridge_unauthorized", True, "handshake token"),
+        ("origin_bridge_generation_mismatch", True, "handshake"),
         ("invalid_request", True, "tool schema"),
         ("worksheet_not_found", True, "project objects"),
         ("path_not_allowed", True, "ORIGIN_MCP_ALLOWED_ROOTS"),

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -142,6 +142,11 @@ def test_focused_profiles_register_their_declared_allow_lists() -> None:
         assert _registered_tool_names(profile) == set(names)
 
 
+def test_data_profile_includes_worksheet_csv_export() -> None:
+    names = _registered_tool_names("data")
+    assert "origin_export_worksheet_csv" in names
+
+
 def test_plot_profile_includes_template_tools() -> None:
     """The focused plot profile includes the user template library."""
 


### PR DESCRIPTION
## Credit and relationship to #24

This PR builds on and incorporates #24 by @LiYunfan-WHU. The follow-up fixes are isolated in commit `e122e38`.

Thank you @LiYunfan-WHU for the original lifecycle hardening work and the real Origin 2025 validation.

Closes #23.

## Summary

Harden the Origin bridge lifecycle so a single bridge owns the configured localhost port, clients recover safely across bridge generations and endpoint moves, stopping an embedded bridge preserves the host Origin process, and embedded Origin never falls back to a second headless OriginExt process.

## Original contribution from #24

- Use Windows-exclusive port binding and reject an occupied port before startup.
- Publish handshake v2 metadata with generation, lease, Origin PID, and client identity.
- Refresh stale client authorization after token or generation changes.
- Give Stop App requests unique request IDs.
- Preserve the host Origin process during embedded bridge shutdown.
- Keep App packaging, recovery guidance, tool registration, and tests synchronized.
- Register `origin_export_worksheet_csv` in the data profile.

## Follow-up fixes

Review and live Origin 2026 testing found three additional edge cases:

1. Explicit host/port/token settings could inherit generation and lease metadata from an unrelated handshake, causing false generation mismatches.
2. A handshake-managed client did not reload a changed handshake when the old endpoint became unavailable after a port move.
3. Origin 2026 may expose the embedded API as `_PyOrigin` while `originpro` imports `PyOrigin`; the name mismatch allowed an OriginExt fallback and created an extra headless `Origin64.exe -Embedding` process.

The follow-up commit now:

- accepts lifecycle metadata only when handshake host, port, and token match the selected connection;
- reloads a changed handshake once after `origin_bridge_unavailable`;
- aliases `_PyOrigin` to `PyOrigin` before importing `originpro`;
- reloads stale OriginExt-backed package state and refuses OriginExt fallback inside embedded Origin;
- preserves legitimate external-Python OriginExt behavior;
- fixes the exclusive-bind mixin typing without changing runtime behavior;
- adds end-to-end regression coverage for all of these paths.

## Validation

- `python -m pytest tests -q` — **778 passed**
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy` — no issues in 74 source files
- `git diff --check`

### Real Origin validation

- #24 reports successful Origin 2025 validation of the original lifecycle changes.
- The combined branch was rebuilt and force-installed for Origin 2026 validation.
- Handshake v2, generation, lease, and Origin PID matched the live bridge.
- `origin-mcp status` and `origin-mcp doctor --ping-origin` succeeded.
- Process count remained one before and after `doctor --ping-origin`; no `-Embedding` child was created.
- Bridge shutdown returned `embedded_noop`, cleared the handshake, released the port, and preserved the host Origin process.
- No project was saved or modified during validation.
