### PR TITLE
Fix bridge lifecycle review issues

### DIFF
--- a/src/origin_mcp/_bridge_server.py
+++ b/src/origin_mcp/_bridge_server.py
@@ -356,7 +356,8 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
                 )
         supplied_generation = request.get("generation")
         if (
-            self.server.generation
+            self.server.token
+            and self.server.generation
             and supplied_generation
             and not hmac.compare_digest(str(supplied_generation), self.server.generation)
         ):
@@ -366,7 +367,8 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             )
         supplied_lease_id = request.get("lease_id")
         if (
-            self.server.lease_id
+            self.server.token
+            and self.server.lease_id
             and supplied_lease_id
             and not hmac.compare_digest(str(supplied_lease_id), self.server.lease_id)
         ):
@@ -429,6 +431,18 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             error_code="unsupported_bridge_method",
         )
 
+    def _originpro_config(self) -> Any | None:
+        op = getattr(self.server.client, "_op", None)
+        if op is None:
+            return None
+        config = getattr(op, "config", None) if op is not None else None
+        if config is None:
+            try:
+                config = importlib.import_module("originpro.config")
+            except Exception:
+                config = None
+        return config
+
     def _bridge_is_external_origin(self) -> bool:
         """True when originpro is driving a separately-spawned OriginExt instance.
 
@@ -441,16 +455,10 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
         available ``po.Exit`` release handle as external automation too.
         """
 
-        op = getattr(self.server.client, "_op", None)
-        if op is None:
+        config = self._originpro_config()
+        if config is None:
             return False
-        config = getattr(op, "config", None) if op is not None else None
-        if config is None:
-            try:
-                config = importlib.import_module("originpro.config")
-            except Exception:
-                config = None
-        if config is None:
+        if bool(getattr(config, "_origin_mcp_attached_host", False)):
             return False
         if bool(getattr(config, "oext", False)):
             return True
@@ -462,6 +470,8 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
         close_origin = bool(params.get("close_origin", False))
         external = self._bridge_is_external_origin()
         embedded = not self.server.tasks_use_worker_thread
+        config = self._originpro_config() if embedded else None
+        attached_host = bool(getattr(config, "_origin_mcp_attached_host", False))
         result: dict[str, Any] = {
             "shutdown_requested": True,
             "release_origin": release_origin,
@@ -477,7 +487,7 @@ class OriginBridgeHandler(socketserver.StreamRequestHandler):
             # Opt out of the external auto-close with ORIGIN_MCP_KEEP_EXTERNAL=1.
             close_spawned = close_origin or (external and not _keep_external_origin())
             release_method = "force_quit" if close_spawned else "detach"
-            if embedded and not close_origin:
+            if embedded and not close_origin and not attached_host:
                 result["origin_release"] = {"preserved": True, "closed": False}
                 result["origin_release_method"] = "embedded_noop"
                 self.server.request_shutdown()

--- a/src/origin_mcp/bridge_client.py
+++ b/src/origin_mcp/bridge_client.py
@@ -6,7 +6,7 @@ import os
 import socket
 import threading
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +64,44 @@ def _optional_int(value: Any) -> int | None:
         return int(value) if value is not None else None
     except (TypeError, ValueError):
         return None
+
+
+def _matching_handshake_lifecycle(
+    handshake: dict[str, Any],
+    *,
+    host: str,
+    port: int,
+    token: str | None,
+) -> dict[str, Any]:
+    handshake_host = handshake.get("host")
+    handshake_port = _optional_int(handshake.get("port"))
+    handshake_token = handshake.get("token")
+    if (
+        isinstance(handshake_host, str)
+        and handshake_host == host
+        and handshake_port == port
+        and isinstance(handshake_token, str)
+        and handshake_token == token
+    ):
+        return handshake
+    return {}
+
+
+def _refresh_matching_lifecycle(config: OriginBridgeConfig) -> OriginBridgeConfig:
+    lifecycle = _matching_handshake_lifecycle(
+        read_handshake() or {},
+        host=config.host,
+        port=config.port,
+        token=config.token,
+    )
+    if not lifecycle:
+        return config
+    return replace(
+        config,
+        generation=_optional_string(lifecycle.get("generation")),
+        lease_id=_optional_string(lifecycle.get("lease_id")),
+        origin_pid=_optional_int(lifecycle.get("origin_pid") or lifecycle.get("pid")),
+    )
 
 
 @dataclass(frozen=True)
@@ -140,17 +178,12 @@ class OriginBridgeConfig:
             )
         )
 
-        handshake_host = handshake.get("host")
-        handshake_port = _optional_int(handshake.get("port"))
-        handshake_token = handshake.get("token")
-        handshake_matches_connection = (
-            isinstance(handshake_host, str)
-            and handshake_host == resolved_host
-            and handshake_port == resolved_port
-            and isinstance(handshake_token, str)
-            and handshake_token == resolved_token
+        lifecycle = _matching_handshake_lifecycle(
+            handshake,
+            host=resolved_host,
+            port=resolved_port,
+            token=resolved_token,
         )
-        lifecycle = handshake if handshake_matches_connection else {}
 
         return cls(
             host=resolved_host,
@@ -184,18 +217,17 @@ class OriginBridgeClient:
             try:
                 return self._request_once(method, params)
             except OriginBridgeError as exc:
-                if (
-                    refresh_attempt
-                    or not self.config.handshake_managed
-                    or exc.error_code
-                    not in {
-                        "origin_bridge_unavailable",
-                        "origin_bridge_unauthorized",
-                        "origin_bridge_generation_mismatch",
-                    }
-                ):
+                if refresh_attempt:
                     raise
-                refreshed = OriginBridgeConfig.from_env(timeout=self.config.timeout)
+                if exc.error_code == "origin_bridge_generation_mismatch":
+                    refreshed = _refresh_matching_lifecycle(self.config)
+                elif self.config.handshake_managed and exc.error_code in {
+                    "origin_bridge_unavailable",
+                    "origin_bridge_unauthorized",
+                }:
+                    refreshed = OriginBridgeConfig.from_env(timeout=self.config.timeout)
+                else:
+                    raise
                 if refreshed == self.config:
                     raise
                 self.close()

--- a/src/origin_mcp/client/base.py
+++ b/src/origin_mcp/client/base.py
@@ -65,46 +65,82 @@ ANALYSIS_XY_OUTPUTS = {"polynomial_fit", "smooth", "interpolate", "normalize"}
 _MIN_TRUNCATION_PREFIX_LEN = 12
 
 
-def _embedded_origin_api() -> Any | None:
-    """Expose Origin's embedded API under the name expected by originpro.
+def _embedded_origin_api_mode() -> str | None:
+    """Return the usable embedded Origin API mode for this interpreter.
 
-    Origin 2026 can provide the host API as ``_PyOrigin`` while originpro still
-    imports ``PyOrigin``. Without the alias, originpro falls back to OriginExt;
-    its first real API call then starts a separate ``Origin64.exe -Embedding``
-    process even though the bridge is already running inside Origin.
+    Some Origin 2026 installations expose only the low-level ``_PyOrigin``
+    extension, not the generated ``PyOrigin`` wrapper that ``originpro``
+    expects. Aliasing the extension directly is unsafe: its functions return
+    bare ``SwigPyObject`` handles without properties such as ``Layers``.
     """
 
     try:
-        return importlib.import_module("PyOrigin")
+        low_level = importlib.import_module("_PyOrigin")
     except ImportError:
-        try:
-            embedded = importlib.import_module("_PyOrigin")
-        except ImportError:
-            return None
-        sys.modules["PyOrigin"] = embedded
-        return embedded
+        low_level = None
+    try:
+        high_level = importlib.import_module("PyOrigin")
+    except ImportError:
+        high_level = None
+    if high_level is not None and high_level is not low_level:
+        return "pyorigin"
+    if low_level is not None:
+        if high_level is low_level:
+            sys.modules.pop("PyOrigin", None)
+        return "low_level"
+    return None
+
+
+def _clear_cached_originpro() -> None:
+    for name in tuple(sys.modules):
+        if name == "originpro" or name.startswith("originpro."):
+            sys.modules.pop(name, None)
+
+
+def _attach_originext_to_host(config: Any) -> None:
+    controller = getattr(config, "po", None)
+    attach = getattr(controller, "Attach", None)
+    if not callable(attach):
+        raise OriginDependencyError(
+            "Origin's embedded Python exposes only the low-level _PyOrigin module, "
+            "and originpro's OriginExt controller cannot attach to the host Origin instance."
+        )
+    try:
+        attach()
+        config._origin_mcp_attached_host = True
+    except Exception as exc:
+        raise OriginDependencyError(
+            "originpro could not attach OriginExt.ApplicationSI to the running host Origin "
+            "instance. Repair Origin's embedded Python/originpro installation."
+        ) from exc
 
 
 def _load_originpro() -> Any:
-    embedded = _embedded_origin_api()
+    embedded_mode = _embedded_origin_api_mode()
     cached_config = sys.modules.get("originpro.config")
-    if embedded is not None and bool(getattr(cached_config, "oext", False)):
-        # A previous bridge generation may already have imported originpro via
-        # its OriginExt fallback. Drop that package generation after installing
-        # the PyOrigin alias so the next import binds to the host process.
-        for name in tuple(sys.modules):
-            if name == "originpro" or name.startswith("originpro."):
-                sys.modules.pop(name, None)
+    if embedded_mode == "pyorigin" and bool(getattr(cached_config, "oext", False)):
+        # A previous bridge generation may have imported originpro before the
+        # native wrapper became available. Reload it against PyOrigin.
+        _clear_cached_originpro()
+    elif (
+        embedded_mode == "low_level"
+        and cached_config is not None
+        and not bool(getattr(cached_config, "oext", False))
+    ):
+        # Remove a package generation created by the old unsafe
+        # ``sys.modules['PyOrigin'] = _PyOrigin`` compatibility alias.
+        _clear_cached_originpro()
 
     op = importlib.import_module("originpro")
-    if embedded is not None:
+    if embedded_mode is not None:
         config = importlib.import_module("originpro.config")
-        if bool(getattr(config, "oext", False)):
-            raise OriginDependencyError(
-                "Origin's embedded Python could not bind originpro to PyOrigin. "
-                "Refusing to fall back to OriginExt because that would start a separate "
-                "Origin automation process."
-            )
+        if embedded_mode == "low_level":
+            if not bool(getattr(config, "oext", False)):
+                raise OriginDependencyError(
+                    "originpro bound to the low-level _PyOrigin extension without its "
+                    "required PyOrigin wrapper."
+                )
+            _attach_originext_to_host(config)
     return op
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -401,6 +401,36 @@ def test_bridge_rejects_stale_generation() -> None:
         thread.join(timeout=2)
 
 
+def test_bridge_ignores_stale_generation_when_authentication_is_disabled() -> None:
+    server = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token=None,
+        generation="current-generation",
+        lease_id="current-generation",
+        client=FakeOriginClient(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        config = OriginBridgeConfig(
+            host=host,
+            port=port,
+            token="stale-token",
+            timeout=2.0,
+            generation="stale-generation",
+            lease_id="stale-generation",
+        )
+
+        result = OriginBridgeClient(config).request("ping")
+
+        assert result["generation"] == "current-generation"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_bridge_port_cannot_be_bound_twice() -> None:
     first = OriginBridgeServer(("127.0.0.1", 0), client=FakeOriginClient())
     try:
@@ -764,6 +794,37 @@ def test_embedded_bridge_shutdown_preserves_host_origin() -> None:
     assert result["origin_release_method"] == "embedded_noop"
     assert result["origin_release"] == {"preserved": True, "closed": False}
     assert fake_client.detached is False
+    assert fake_client.force_closed is False
+
+
+def test_embedded_bridge_shutdown_detaches_attached_host_origin() -> None:
+    import types
+
+    fake_client = FakeOriginClient()
+    op_mod = types.ModuleType("originpro")
+    cfg = types.ModuleType("originpro.config")
+    cfg.oext = True
+    cfg._origin_mcp_attached_host = True
+    op_mod.config = cfg
+    fake_client._op = op_mod  # type: ignore[attr-defined]
+
+    server = OriginEmbeddedBridgeServer(
+        ("127.0.0.1", 0),
+        client=fake_client,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        result = bridge_client(server).request("shutdown")
+        thread.join(timeout=2)
+    finally:
+        server.server_close()
+
+    assert result["embedded_origin"] is True
+    assert result["external_origin"] is False
+    assert result["origin_release_method"] == "detach"
+    assert result["origin_release"] == {"detached": True, "closed": False}
+    assert fake_client.detached is True
     assert fake_client.force_closed is False
 
 

--- a/tests/test_bridge_handshake.py
+++ b/tests/test_bridge_handshake.py
@@ -292,6 +292,55 @@ def test_handshake_managed_client_refreshes_rotated_token(
         thread.join(timeout=2)
 
 
+def test_env_token_client_refreshes_rotated_lifecycle_metadata(
+    isolated_handshake: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "stable-env-token"
+    monkeypatch.setenv("ORIGIN_MCP_BRIDGE_TOKEN", token)
+    server = OriginBridgeServer(
+        ("127.0.0.1", 0),
+        token=token,
+        generation="generation-one",
+        lease_id="generation-one",
+        client=FakeOriginClient(),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        bridge_handshake.write_handshake(
+            host,
+            port,
+            token,
+            generation="generation-one",
+            lease_id="generation-one",
+        )
+        client = OriginBridgeClient(OriginBridgeConfig.from_env(timeout=2.0))
+        assert client.config.handshake_managed is False
+
+        server.generation = "generation-two"
+        server.lease_id = "generation-two"
+        bridge_handshake.write_handshake(
+            host,
+            port,
+            token,
+            generation="generation-two",
+            lease_id="generation-two",
+        )
+
+        result = client.request("ping")
+
+        assert result["generation"] == "generation-two"
+        assert client.config.token == token
+        assert client.config.generation == "generation-two"
+        assert client.config.lease_id == "generation-two"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_handshake_managed_client_refreshes_moved_endpoint(
     isolated_handshake: Path,
 ) -> None:

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -20,44 +20,42 @@ from origin_mcp.chart_palette import (
 )
 from origin_mcp.client import base as client_base
 from origin_mcp.compat import PLOT_TYPE_CATALOG
-from origin_mcp.errors import OriginDependencyError, OriginOperationError
+from origin_mcp.errors import OriginOperationError
 from origin_mcp.origin_client import GraphRef, OriginClient, WorksheetRef
 
 
-def test_origin_client_aliases_embedded_api_before_importing_originpro(
+def test_origin_client_uses_native_pyorigin_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    embedded = SimpleNamespace(name="embedded-pyorigin")
+    low_level = SimpleNamespace(name="low-level-pyorigin")
+    high_level = SimpleNamespace(name="native-pyorigin")
     originpro = SimpleNamespace(name="originpro")
     config = SimpleNamespace(oext=False)
     imports: list[str] = []
 
     def fake_import(name: str) -> Any:
         imports.append(name)
-        if name == "PyOrigin":
-            raise ModuleNotFoundError("No module named 'PyOrigin'", name="PyOrigin")
         if name == "_PyOrigin":
-            return embedded
+            return low_level
+        if name == "PyOrigin":
+            return high_level
         if name == "originpro":
-            assert sys.modules["PyOrigin"] is embedded
             return originpro
         if name == "originpro.config":
             return config
         raise AssertionError(f"Unexpected import: {name}")
 
     monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
-    try:
-        assert OriginClient().op is originpro
-    finally:
-        sys.modules.pop("PyOrigin", None)
+    assert OriginClient().op is originpro
 
-    assert imports == ["PyOrigin", "_PyOrigin", "originpro", "originpro.config"]
+    assert imports == ["_PyOrigin", "PyOrigin", "originpro", "originpro.config"]
 
 
-def test_origin_client_reloads_cached_originext_after_embedded_api_appears(
+def test_origin_client_reloads_cached_originext_after_native_wrapper_appears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    embedded = SimpleNamespace(name="embedded-pyorigin")
+    low_level = SimpleNamespace(name="low-level-pyorigin")
+    high_level = SimpleNamespace(name="native-pyorigin")
     stale_originpro = SimpleNamespace(name="stale-originpro")
     stale_config = SimpleNamespace(oext=True)
     fresh_originpro = SimpleNamespace(name="fresh-originpro")
@@ -66,10 +64,10 @@ def test_origin_client_reloads_cached_originext_after_embedded_api_appears(
     monkeypatch.setitem(sys.modules, "originpro.config", stale_config)
 
     def fake_import(name: str) -> Any:
-        if name == "PyOrigin":
-            raise ModuleNotFoundError("No module named 'PyOrigin'", name="PyOrigin")
         if name == "_PyOrigin":
-            return embedded
+            return low_level
+        if name == "PyOrigin":
+            return high_level
         if name == "originpro":
             assert "originpro" not in sys.modules
             assert "originpro.config" not in sys.modules
@@ -79,18 +77,19 @@ def test_origin_client_reloads_cached_originext_after_embedded_api_appears(
         raise AssertionError(f"Unexpected import: {name}")
 
     monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
-    try:
-        assert OriginClient().op is fresh_originpro
-    finally:
-        sys.modules.pop("PyOrigin", None)
+    assert OriginClient().op is fresh_originpro
 
 
-def test_origin_client_refuses_originext_fallback_inside_origin(
+def test_origin_client_attaches_originext_when_only_low_level_api_is_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    embedded = SimpleNamespace(name="embedded-pyorigin")
+    embedded = SimpleNamespace(name="low-level-pyorigin")
     originpro = SimpleNamespace(name="originpro")
-    config = SimpleNamespace(oext=True)
+    attached: list[bool] = []
+    config = SimpleNamespace(
+        oext=True,
+        po=SimpleNamespace(Attach=lambda: attached.append(True)),
+    )
 
     def fake_import(name: str) -> Any:
         if name == "PyOrigin":
@@ -104,11 +103,43 @@ def test_origin_client_refuses_originext_fallback_inside_origin(
         raise AssertionError(f"Unexpected import: {name}")
 
     monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
-    try:
-        with pytest.raises(OriginDependencyError, match="Refusing to fall back to OriginExt"):
-            _ = OriginClient().op
-    finally:
-        sys.modules.pop("PyOrigin", None)
+    assert OriginClient().op is originpro
+    assert attached == [True]
+    assert config._origin_mcp_attached_host is True
+
+
+def test_origin_client_discards_unsafe_low_level_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    low_level = SimpleNamespace(name="low-level-pyorigin")
+    stale_originpro = SimpleNamespace(name="stale-originpro")
+    stale_config = SimpleNamespace(oext=False)
+    fresh_originpro = SimpleNamespace(name="fresh-originpro")
+    attached: list[bool] = []
+    fresh_config = SimpleNamespace(
+        oext=True,
+        po=SimpleNamespace(Attach=lambda: attached.append(True)),
+    )
+    monkeypatch.setitem(sys.modules, "PyOrigin", low_level)
+    monkeypatch.setitem(sys.modules, "originpro", stale_originpro)
+    monkeypatch.setitem(sys.modules, "originpro.config", stale_config)
+
+    def fake_import(name: str) -> Any:
+        if name in {"_PyOrigin", "PyOrigin"}:
+            return low_level
+        if name == "originpro":
+            assert "PyOrigin" not in sys.modules
+            assert "originpro" not in sys.modules
+            return fresh_originpro
+        if name == "originpro.config":
+            return fresh_config
+        raise AssertionError(f"Unexpected import: {name}")
+
+    monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
+
+    assert OriginClient().op is fresh_originpro
+    assert attached == [True]
+    assert fresh_config._origin_mcp_attached_host is True
 
 
 def test_origin_client_keeps_originext_available_outside_origin(
@@ -128,7 +159,7 @@ def test_origin_client_keeps_originext_available_outside_origin(
     monkeypatch.setattr(client_base.importlib, "import_module", fake_import)
 
     assert OriginClient().op is originpro
-    assert imports == ["PyOrigin", "_PyOrigin", "originpro"]
+    assert imports == ["_PyOrigin", "PyOrigin", "originpro"]
 
 
 def test_read_table_csv(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- apply generation and lease validation only when bridge authentication is enabled
- refresh matching handshake lifecycle metadata for environment-token clients after generation mismatch
- support Origin 2026 installations that expose only low-level `_PyOrigin` by attaching `OriginExt.ApplicationSI` to the existing host Origin
- detach host-attached OriginExt connections during embedded bridge shutdown without closing Origin

## Root cause

The no-auth bridge path still enforced authenticated lifecycle metadata, and clients using an environment token did not reload matching lifecycle state. Separately, aliasing raw `_PyOrigin` as the high-level `PyOrigin` wrapper returned bare `SwigPyObject` handles that originpro could not use.

## Validation

- `python scripts\release_check.py` — PASS (782 tests, Ruff, format, mypy, release consistency)
- `python scripts\real_origin_health.py --show-origin` — PASS
- `python -m origin_mcp doctor --ping-origin` — PASS
- verified the installed App hashes match the working source
- verified only the original Origin64 process remained running