### PR TITLE
Prepare release 0.1.4

### DIFF
--- a/scripts/build_origin_app.py
+++ b/scripts/build_origin_app.py
@@ -261,6 +261,7 @@ def _write_package_ini(path: Path, app_name: str, description: str) -> None:
         "Copyrightyear": "2026",
     }
     config["Log"] = {
+        "v0.1.4": "Add smart plotting and harden bridge lifecycle recovery.",
         "v0.1.3": "Improve MCP tool schemas and expand Origin workflow coverage.",
         "v0.1.2": "Split bridge startup and shutdown into two App buttons.",
         "v0.1.1": "Single-button bridge toggle with corrected OPX install root.",

--- a/src/origin_mcp/__init__.py
+++ b/src/origin_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/src/origin_mcp/client/table_plot.py
+++ b/src/origin_mcp/client/table_plot.py
@@ -1336,12 +1336,15 @@ class _TablePlotMixin(_OriginClientBase):
         )
 
         mark_result = None
+        marks = defaults.get("marks", {})
+        line_width = decision_value(marks, "line_width") if "line_width" in marks else None
         symbol_size = decision_value(defaults, "marks", "symbol_size")
         transparency = decision_value(defaults, "marks", "transparency")
-        if symbol_size is not None or transparency is not None:
+        if line_width is not None or symbol_size is not None or transparency is not None:
             try:
                 mark_result = self.set_plot_style(
                     graph_name=graph_name,
+                    line_width=line_width,
                     symbol_size=symbol_size,
                     transparency=transparency,
                 )

--- a/src/origin_mcp/visual_defaults.py
+++ b/src/origin_mcp/visual_defaults.py
@@ -20,6 +20,8 @@ from .nature_style_profiles import resolve_nature_style_profile
 from .text_format import humanize_field_name, infer_axis_title, infer_series_labels
 
 DEFAULT_HEATMAP_COLORMAP = "viridis"
+DEFAULT_SMART_ANNOTATION_FONT_SIZE = 20
+DEFAULT_SMART_LINE_WIDTH = 2.5
 
 _ISO_DATETIME_PATTERN = re.compile(
     r"^\d{4}[-/]\d{2}[-/]\d{2}"
@@ -154,6 +156,21 @@ def resolve_visual_defaults(
         explicit=mark_transparency,
         style_mode=style_mode,
     )
+    if context.chart_type == "line":
+        line_width = _decision(
+            (
+                resolve_nature_style_profile("screen").line_width
+                if style_mode == "nature"
+                else DEFAULT_SMART_LINE_WIDTH
+            ),
+            (
+                "nature_series_stroke"
+                if style_mode == "nature"
+                else "minimum_readable_series_stroke"
+            ),
+        )
+    else:
+        line_width = _decision(None, "chart_type_has_no_default_series_line")
     x_rotation = _x_tick_rotation(context)
     page_aspect_ratio, bottom_margin = _rotated_label_canvas(
         context,
@@ -288,7 +305,12 @@ def resolve_visual_defaults(
         font_size=(
             resolve_nature_style_profile("screen").annotation_font_size
             if style_mode == "nature"
-            else 8
+            else DEFAULT_SMART_ANNOTATION_FONT_SIZE
+        ),
+        font_reason=(
+            "nature_annotation_typography"
+            if style_mode == "nature"
+            else "match_axis_tick_typography"
         ),
         layer_series_counts=[
             len(y_names_actual) or context.series_count,
@@ -303,6 +325,11 @@ def resolve_visual_defaults(
         label_position = decision_value(data_labels, "position")
         if label_position == "right":
             right_margin = _max_optional(right_margin, 0.14)
+            if x_scale is not None and x_min is not None and x_max is not None:
+                x_span = max(x_max - x_min, 1e-12)
+                padded_to = x_max + (x_span * 0.12)
+                if float(x_scale["to"]) < padded_to:
+                    x_scale = {**x_scale, "to": padded_to}
         top_margin = 0.1 if label_position == "above" else None
     else:
         top_margin = None
@@ -338,6 +365,7 @@ def resolve_visual_defaults(
         },
         "palette_name": palette,
         "marks": {
+            "line_width": line_width,
             "symbol_size": symbol_size,
             "transparency": transparency,
         },
@@ -929,6 +957,7 @@ def _data_label_defaults(
     y_min: float | None,
     y_max: float | None,
     font_size: int,
+    font_reason: str,
     layer_series_counts: list[int],
     layer_formats: list[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -995,7 +1024,7 @@ def _data_label_defaults(
         "position": _decision(position if show else None, reason),
         "font_size": _decision(
             font_size if show else None,
-            ("nature_annotation_typography" if font_size >= 20 else "quiet_annotation_typography"),
+            font_reason,
         ),
         "value_source": _decision("y" if show else None, "axis_title_carries_metric_and_unit"),
         "layer_series_counts": _decision(

--- a/tests/test_origin_client.py
+++ b/tests/test_origin_client.py
@@ -1695,6 +1695,7 @@ def test_apply_smart_visual_defaults_formats_axes_marks_and_legend(
             "position": {"value": "inside_upper_left"},
         },
         "marks": {
+            "line_width": {"value": 2.5},
             "symbol_size": {"value": 3.5},
             "transparency": {"value": 35.0},
         },
@@ -1736,7 +1737,14 @@ def test_apply_smart_visual_defaults_formats_axes_marks_and_legend(
     assert "layer.y.from=0;" in scripts[0]
     assert "page.height=page.width/1.05;" in scripts[0]
     assert "page -fls -u -ml 0.08 -mt 0.05 -mr 0.05 -mb 0.25;" in scripts[0]
-    assert style_calls == [{"graph_name": "Graph1", "symbol_size": 3.5, "transparency": 35.0}]
+    assert style_calls == [
+        {
+            "graph_name": "Graph1",
+            "line_width": 2.5,
+            "symbol_size": 3.5,
+            "transparency": 35.0,
+        }
+    ]
     assert legend_calls == [
         {
             "graph_name": "Graph1",

--- a/tests/test_visual_defaults.py
+++ b/tests/test_visual_defaults.py
@@ -473,6 +473,13 @@ def test_smart_line_labels_only_latest_values_and_reserves_right_space() -> None
     assert decision_value(defaults, "annotations", "data_labels", "scope") == "end"
     assert decision_value(defaults, "annotations", "data_labels", "position") == "right"
     assert decision_value(defaults, "annotations", "data_labels", "value_source") == "y"
+    assert decision_value(defaults, "annotations", "data_labels", "font_size") == 20
+    assert defaults["annotations"]["data_labels"]["font_size"]["reason"] == (
+        "match_axis_tick_typography"
+    )
+    assert decision_value(defaults, "marks", "line_width") == 2.5
+    assert defaults["marks"]["line_width"]["reason"] == "minimum_readable_series_stroke"
+    assert decision_value(defaults, "axes", "x_scale")["to"] >= 12.32
     assert decision_value(defaults, "annotations", "data_labels", "layer_formats") == [
         {"number_format": "decimal", "decimal_places": 2}
     ]
@@ -493,6 +500,7 @@ def test_nature_data_labels_use_large_annotation_typography() -> None:
     assert defaults["annotations"]["data_labels"]["font_size"]["reason"] == (
         "nature_annotation_typography"
     )
+    assert decision_value(defaults, "marks", "line_width") == 3.0
 
 
 def test_smart_column_labels_compact_single_series_and_reserves_top_space() -> None:


### PR DESCRIPTION
## Summary

- bump the package and Origin App version to 0.1.4
- make default line plots more readable with 2.5 pt series strokes
- match automatic endpoint labels to the 20 pt axis tick typography
- expand the numeric X range for right-side endpoint labels to prevent clipping
- add regression coverage for the new visual defaults and their Origin application path

## Validation

- `python scripts\release_check.py` — PASS (782 tests, Ruff, format, mypy, release consistency)
- `python scripts\real_origin_health.py --show-origin` — PASS
- `python scripts\real_origin_smoke.py --keep-origin-open --show-origin` — PASS
- wheel and sdist pass `twine check`
- wheel installs as 0.1.4 in an isolated environment
- Start and Stop OPX files were rebuilt from a clean App directory, reinstalled, and verified against real Origin
- installed App source hashes match the release branch

## Release assets

The GitHub Release will include the wheel, sdist, Start OPX, and Stop OPX. Test-rendered figures are intentionally excluded.